### PR TITLE
feat: Member/Auth API 서비스 및 컨트롤러 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,6 +80,11 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+    // Testcontainers (통합 테스트용 Docker 컨테이너)
+    testImplementation("org.springframework.boot:spring-boot-testcontainers")
+    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("com.redis:testcontainers-redis:2.2.4")
 }
 
 // BOM (Bill of Materials) import
@@ -87,6 +92,7 @@ dependencyManagement {
     imports {
         mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
         mavenBom("org.springframework.ai:spring-ai-bom:${property("springAiVersion")}")
+        mavenBom("org.testcontainers:testcontainers-bom:1.21.4")
     }
 }
 

--- a/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
@@ -1,0 +1,55 @@
+package com.pace.server.domain.auth.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.auth.dto.ReissueRequest;
+import com.pace.server.domain.auth.dto.TokenResponse;
+import com.pace.server.domain.auth.service.AuthService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.oauth2.CustomOAuth2User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+/**
+ * 인증 API 컨트롤러.
+ * 토큰 재발급 및 로그아웃 API 제공.
+ */
+@Tag(name = "Auth", description = "인증 API")
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 토큰 재발급 API
+     * Refresh Token으로 새로운 Access/Refresh Token 발급 (RTR 적용)
+     */
+    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새 Access/Refresh Token 발급")
+    @PostMapping("/reissue")
+    public ApiResponse<TokenResponse> reissue(@Valid @RequestBody ReissueRequest request) {
+        TokenResponse response = authService.reissue(request);
+        return ApiResponse.success(SuccessCode.TOKEN_REISSUED, response);
+    }
+
+    /**
+     * 로그아웃 API
+     * Redis에서 Refresh Token 삭제
+     */
+    @Operation(summary = "로그아웃", description = "Refresh Token 삭제")
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(@AuthenticationPrincipal CustomOAuth2User principal) {
+        authService.logout(principal.getUserId());
+        return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS);
+    }
+}

--- a/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
@@ -11,7 +11,7 @@ import com.pace.server.domain.auth.dto.TokenResponse;
 import com.pace.server.domain.auth.service.AuthService;
 import com.pace.server.global.common.code.SuccessCode;
 import com.pace.server.global.common.response.ApiResponse;
-import com.pace.server.global.security.oauth2.CustomOAuth2User;
+import com.pace.server.global.security.jwt.JwtAuthentication;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,8 +47,8 @@ public class AuthController {
 	 */
 	@Operation(summary = "로그아웃", description = "Refresh Token 삭제")
 	@PostMapping("/logout")
-	public ApiResponse<Void> logout(@AuthenticationPrincipal CustomOAuth2User principal) {
-		authService.logout(principal.getUserId());
+	public ApiResponse<Void> logout(@AuthenticationPrincipal JwtAuthentication principal) {
+		authService.logout(principal.userId());
 		return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS);
 	}
 }

--- a/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pace/server/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.pace.server.domain.auth.controller;
 
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,8 +18,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
 /**
  * 인증 API 컨트롤러.
  * 토큰 재발급 및 로그아웃 API 제공.
@@ -29,27 +28,27 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @RequiredArgsConstructor
 public class AuthController {
 
-    private final AuthService authService;
+	private final AuthService authService;
 
-    /**
-     * 토큰 재발급 API
-     * Refresh Token으로 새로운 Access/Refresh Token 발급 (RTR 적용)
-     */
-    @Operation(summary = "토큰 재발급", description = "Refresh Token으로 새 Access/Refresh Token 발급")
-    @PostMapping("/reissue")
-    public ApiResponse<TokenResponse> reissue(@Valid @RequestBody ReissueRequest request) {
-        TokenResponse response = authService.reissue(request);
-        return ApiResponse.success(SuccessCode.TOKEN_REISSUED, response);
-    }
+	/**
+	 * 토큰 재발급 API
+	 * Refresh Token으로 새로운 Access/Refresh Token 발급 (RTR 적용)
+	 */
+	@Operation(summary = "토큰 재발급", description = "Refresh Token으로 새 Access/Refresh Token 발급")
+	@PostMapping("/reissue")
+	public ApiResponse<TokenResponse> reissue(@Valid @RequestBody ReissueRequest request) {
+		TokenResponse response = authService.reissue(request);
+		return ApiResponse.success(SuccessCode.TOKEN_REISSUED, response);
+	}
 
-    /**
-     * 로그아웃 API
-     * Redis에서 Refresh Token 삭제
-     */
-    @Operation(summary = "로그아웃", description = "Refresh Token 삭제")
-    @PostMapping("/logout")
-    public ApiResponse<Void> logout(@AuthenticationPrincipal CustomOAuth2User principal) {
-        authService.logout(principal.getUserId());
-        return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS);
-    }
+	/**
+	 * 로그아웃 API
+	 * Redis에서 Refresh Token 삭제
+	 */
+	@Operation(summary = "로그아웃", description = "Refresh Token 삭제")
+	@PostMapping("/logout")
+	public ApiResponse<Void> logout(@AuthenticationPrincipal CustomOAuth2User principal) {
+		authService.logout(principal.getUserId());
+		return ApiResponse.success(SuccessCode.LOGOUT_SUCCESS);
+	}
 }

--- a/src/main/java/com/pace/server/domain/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/pace/server/domain/auth/dto/ReissueRequest.java
@@ -1,0 +1,10 @@
+package com.pace.server.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 토큰 재발급 요청 DTO
+ */
+public record ReissueRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다") String refreshToken) {
+}

--- a/src/main/java/com/pace/server/domain/auth/dto/ReissueRequest.java
+++ b/src/main/java/com/pace/server/domain/auth/dto/ReissueRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.NotBlank;
  * 토큰 재발급 요청 DTO
  */
 public record ReissueRequest(
-        @NotBlank(message = "Refresh Token은 필수입니다") String refreshToken) {
+	@NotBlank(message = "Refresh Token은 필수입니다") String refreshToken) {
 }

--- a/src/main/java/com/pace/server/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/pace/server/domain/auth/dto/TokenResponse.java
@@ -4,6 +4,6 @@ package com.pace.server.domain.auth.dto;
  * JWT 토큰 응답 DTO
  */
 public record TokenResponse(
-        String accessToken,
-        String refreshToken) {
+	String accessToken,
+	String refreshToken) {
 }

--- a/src/main/java/com/pace/server/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/pace/server/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,9 @@
+package com.pace.server.domain.auth.dto;
+
+/**
+ * JWT 토큰 응답 DTO
+ */
+public record TokenResponse(
+        String accessToken,
+        String refreshToken) {
+}

--- a/src/main/java/com/pace/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pace/server/domain/auth/service/AuthService.java
@@ -24,65 +24,65 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenStore refreshTokenStore;
-    private final UserRepository userRepository;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RefreshTokenStore refreshTokenStore;
+	private final UserRepository userRepository;
 
-    /**
-     * 토큰 재발급 (Refresh Token Rotation 적용)
-     *
-     * @param request Refresh Token 요청
-     * @return 새로운 Access/Refresh Token
-     */
-    @Transactional
-    public TokenResponse reissue(ReissueRequest request) {
-        String refreshToken = request.refreshToken();
+	/**
+	 * 토큰 재발급 (Refresh Token Rotation 적용)
+	 *
+	 * @param request Refresh Token 요청
+	 * @return 새로운 Access/Refresh Token
+	 */
+	@Transactional
+	public TokenResponse reissue(ReissueRequest request) {
+		String refreshToken = request.refreshToken();
 
-        // 1. Refresh Token 유효성 검증
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
-            throw new AuthException(ErrorCode.TOKEN_INVALID);
-        }
+		// 1. Refresh Token 유효성 검증
+		if (!jwtTokenProvider.validateToken(refreshToken)) {
+			throw new AuthException(ErrorCode.TOKEN_INVALID);
+		}
 
-        // 2. 토큰에서 userId 추출
-        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+		// 2. 토큰에서 userId 추출
+		Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
 
-        // 3. Redis에 저장된 RT와 비교
-        if (!refreshTokenStore.matches(userId, refreshToken)) {
-            log.warn("Refresh token mismatch for user: {}", userId);
-            throw new AuthException(ErrorCode.REFRESH_TOKEN_MISMATCH);
-        }
+		// 3. Redis에 저장된 RT와 비교
+		if (!refreshTokenStore.matches(userId, refreshToken)) {
+			log.warn("Refresh token mismatch for user: {}", userId);
+			throw new AuthException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+		}
 
-        // 4. 유저 조회
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+		// 4. 유저 조회
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
 
-        // 5. 비활성화된 사용자 체크
-        if (!user.isActive()) {
-            throw new AuthException(ErrorCode.USER_INACTIVE);
-        }
+		// 5. 비활성화된 사용자 체크
+		if (!user.isActive()) {
+			throw new AuthException(ErrorCode.USER_INACTIVE);
+		}
 
-        // 6. 새 토큰 발급
-        String newAccessToken = jwtTokenProvider.createAccessToken(
-                user.getId(), user.getEmail(), user.getRole().name());
-        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+		// 6. 새 토큰 발급
+		String newAccessToken = jwtTokenProvider.createAccessToken(
+			user.getId(), user.getEmail(), user.getRole().name());
+		String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
 
-        // 7. RTR: 기존 RT 삭제 후 새 RT 저장
-        refreshTokenStore.delete(userId);
-        refreshTokenStore.save(userId, newRefreshToken, jwtTokenProvider.getRefreshTokenExpiry());
+		// 7. RTR: 기존 RT 삭제 후 새 RT 저장
+		refreshTokenStore.delete(userId);
+		refreshTokenStore.save(userId, newRefreshToken, jwtTokenProvider.getRefreshTokenExpiry());
 
-        log.info("Token reissued for user: {}", userId);
+		log.info("Token reissued for user: {}", userId);
 
-        return new TokenResponse(newAccessToken, newRefreshToken);
-    }
+		return new TokenResponse(newAccessToken, newRefreshToken);
+	}
 
-    /**
-     * 로그아웃 - Redis에서 Refresh Token 삭제
-     *
-     * @param userId 사용자 ID
-     */
-    @Transactional
-    public void logout(Long userId) {
-        refreshTokenStore.delete(userId);
-        log.info("User logged out: {}", userId);
-    }
+	/**
+	 * 로그아웃 - Redis에서 Refresh Token 삭제
+	 *
+	 * @param userId 사용자 ID
+	 */
+	@Transactional
+	public void logout(Long userId) {
+		refreshTokenStore.delete(userId);
+		log.info("User logged out: {}", userId);
+	}
 }

--- a/src/main/java/com/pace/server/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pace/server/domain/auth/service/AuthService.java
@@ -1,0 +1,88 @@
+package com.pace.server.domain.auth.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.auth.dto.ReissueRequest;
+import com.pace.server.domain.auth.dto.TokenResponse;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.AuthException;
+import com.pace.server.global.security.handler.RefreshTokenStore;
+import com.pace.server.global.security.jwt.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 인증 서비스.
+ * 토큰 재발급(RTR) 및 로그아웃 처리.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenStore refreshTokenStore;
+    private final UserRepository userRepository;
+
+    /**
+     * 토큰 재발급 (Refresh Token Rotation 적용)
+     *
+     * @param request Refresh Token 요청
+     * @return 새로운 Access/Refresh Token
+     */
+    @Transactional
+    public TokenResponse reissue(ReissueRequest request) {
+        String refreshToken = request.refreshToken();
+
+        // 1. Refresh Token 유효성 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new AuthException(ErrorCode.TOKEN_INVALID);
+        }
+
+        // 2. 토큰에서 userId 추출
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+
+        // 3. Redis에 저장된 RT와 비교
+        if (!refreshTokenStore.matches(userId, refreshToken)) {
+            log.warn("Refresh token mismatch for user: {}", userId);
+            throw new AuthException(ErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        // 4. 유저 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+
+        // 5. 비활성화된 사용자 체크
+        if (!user.isActive()) {
+            throw new AuthException(ErrorCode.USER_INACTIVE);
+        }
+
+        // 6. 새 토큰 발급
+        String newAccessToken = jwtTokenProvider.createAccessToken(
+                user.getId(), user.getEmail(), user.getRole().name());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        // 7. RTR: 기존 RT 삭제 후 새 RT 저장
+        refreshTokenStore.delete(userId);
+        refreshTokenStore.save(userId, newRefreshToken, jwtTokenProvider.getRefreshTokenExpiry());
+
+        log.info("Token reissued for user: {}", userId);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    /**
+     * 로그아웃 - Redis에서 Refresh Token 삭제
+     *
+     * @param userId 사용자 ID
+     */
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenStore.delete(userId);
+        log.info("User logged out: {}", userId);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/controller/InterestController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/InterestController.java
@@ -16,7 +16,7 @@ import com.pace.server.domain.member.dto.response.InterestResponse;
 import com.pace.server.domain.member.service.InterestService;
 import com.pace.server.global.common.code.SuccessCode;
 import com.pace.server.global.common.response.ApiResponse;
-import com.pace.server.global.security.oauth2.CustomOAuth2User;
+import com.pace.server.global.security.jwt.JwtAuthentication;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -38,26 +38,26 @@ public class InterestController {
 	@Operation(summary = "관심 항목 목록 조회")
 	@GetMapping
 	public ApiResponse<List<InterestResponse>> getInterests(
-		@AuthenticationPrincipal CustomOAuth2User principal) {
-		List<InterestResponse> response = interestService.getInterests(principal.getUserId());
+			@AuthenticationPrincipal JwtAuthentication principal) {
+		List<InterestResponse> response = interestService.getInterests(principal.userId());
 		return ApiResponse.ok(response);
 	}
 
 	@Operation(summary = "관심 항목 추가", description = "키워드/주식/코인 추가 (최대 20개)")
 	@PostMapping
 	public ApiResponse<InterestResponse> addInterest(
-		@AuthenticationPrincipal CustomOAuth2User principal,
-		@Valid @RequestBody AddInterestRequest request) {
-		InterestResponse response = interestService.addInterest(principal.getUserId(), request);
+			@AuthenticationPrincipal JwtAuthentication principal,
+			@Valid @RequestBody AddInterestRequest request) {
+		InterestResponse response = interestService.addInterest(principal.userId(), request);
 		return ApiResponse.success(SuccessCode.CREATED, response);
 	}
 
 	@Operation(summary = "관심 항목 삭제")
 	@DeleteMapping("/{itemId}")
 	public ApiResponse<Void> deleteInterest(
-		@AuthenticationPrincipal CustomOAuth2User principal,
-		@PathVariable Long itemId) {
-		interestService.deleteInterest(principal.getUserId(), itemId);
+			@AuthenticationPrincipal JwtAuthentication principal,
+			@PathVariable Long itemId) {
+		interestService.deleteInterest(principal.userId(), itemId);
 		return ApiResponse.success(SuccessCode.DELETED);
 	}
 }

--- a/src/main/java/com/pace/server/domain/member/controller/InterestController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/InterestController.java
@@ -33,31 +33,31 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class InterestController {
 
-    private final InterestService interestService;
+	private final InterestService interestService;
 
-    @Operation(summary = "관심 항목 목록 조회")
-    @GetMapping
-    public ApiResponse<List<InterestResponse>> getInterests(
-            @AuthenticationPrincipal CustomOAuth2User principal) {
-        List<InterestResponse> response = interestService.getInterests(principal.getUserId());
-        return ApiResponse.ok(response);
-    }
+	@Operation(summary = "관심 항목 목록 조회")
+	@GetMapping
+	public ApiResponse<List<InterestResponse>> getInterests(
+		@AuthenticationPrincipal CustomOAuth2User principal) {
+		List<InterestResponse> response = interestService.getInterests(principal.getUserId());
+		return ApiResponse.ok(response);
+	}
 
-    @Operation(summary = "관심 항목 추가", description = "키워드/주식/코인 추가 (최대 20개)")
-    @PostMapping
-    public ApiResponse<InterestResponse> addInterest(
-            @AuthenticationPrincipal CustomOAuth2User principal,
-            @Valid @RequestBody AddInterestRequest request) {
-        InterestResponse response = interestService.addInterest(principal.getUserId(), request);
-        return ApiResponse.success(SuccessCode.CREATED, response);
-    }
+	@Operation(summary = "관심 항목 추가", description = "키워드/주식/코인 추가 (최대 20개)")
+	@PostMapping
+	public ApiResponse<InterestResponse> addInterest(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@Valid @RequestBody AddInterestRequest request) {
+		InterestResponse response = interestService.addInterest(principal.getUserId(), request);
+		return ApiResponse.success(SuccessCode.CREATED, response);
+	}
 
-    @Operation(summary = "관심 항목 삭제")
-    @DeleteMapping("/{itemId}")
-    public ApiResponse<Void> deleteInterest(
-            @AuthenticationPrincipal CustomOAuth2User principal,
-            @PathVariable Long itemId) {
-        interestService.deleteInterest(principal.getUserId(), itemId);
-        return ApiResponse.success(SuccessCode.DELETED);
-    }
+	@Operation(summary = "관심 항목 삭제")
+	@DeleteMapping("/{itemId}")
+	public ApiResponse<Void> deleteInterest(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@PathVariable Long itemId) {
+		interestService.deleteInterest(principal.getUserId(), itemId);
+		return ApiResponse.success(SuccessCode.DELETED);
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/controller/InterestController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/InterestController.java
@@ -1,0 +1,63 @@
+package com.pace.server.domain.member.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.member.dto.request.AddInterestRequest;
+import com.pace.server.domain.member.dto.response.InterestResponse;
+import com.pace.server.domain.member.service.InterestService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.oauth2.CustomOAuth2User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 관심 항목 API 컨트롤러.
+ * 뉴스 키워드, 주식 종목, 코인 관심사 관리.
+ */
+@Tag(name = "Interest", description = "관심 항목 API")
+@RestController
+@RequestMapping("/api/v1/members/me/interests")
+@RequiredArgsConstructor
+public class InterestController {
+
+    private final InterestService interestService;
+
+    @Operation(summary = "관심 항목 목록 조회")
+    @GetMapping
+    public ApiResponse<List<InterestResponse>> getInterests(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+        List<InterestResponse> response = interestService.getInterests(principal.getUserId());
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "관심 항목 추가", description = "키워드/주식/코인 추가 (최대 20개)")
+    @PostMapping
+    public ApiResponse<InterestResponse> addInterest(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @Valid @RequestBody AddInterestRequest request) {
+        InterestResponse response = interestService.addInterest(principal.getUserId(), request);
+        return ApiResponse.success(SuccessCode.CREATED, response);
+    }
+
+    @Operation(summary = "관심 항목 삭제")
+    @DeleteMapping("/{itemId}")
+    public ApiResponse<Void> deleteInterest(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @PathVariable Long itemId) {
+        interestService.deleteInterest(principal.getUserId(), itemId);
+        return ApiResponse.success(SuccessCode.DELETED);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/MemberController.java
@@ -13,7 +13,7 @@ import com.pace.server.domain.member.dto.response.MemberResponse;
 import com.pace.server.domain.member.service.MemberService;
 import com.pace.server.global.common.code.SuccessCode;
 import com.pace.server.global.common.response.ApiResponse;
-import com.pace.server.global.security.oauth2.CustomOAuth2User;
+import com.pace.server.global.security.jwt.JwtAuthentication;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,25 +35,25 @@ public class MemberController {
 	@Operation(summary = "내 프로필 조회")
 	@GetMapping("/me")
 	public ApiResponse<MemberResponse> getMyProfile(
-		@AuthenticationPrincipal CustomOAuth2User principal) {
-		MemberResponse response = memberService.getProfile(principal.getUserId());
+			@AuthenticationPrincipal JwtAuthentication principal) {
+		MemberResponse response = memberService.getProfile(principal.userId());
 		return ApiResponse.ok(response);
 	}
 
 	@Operation(summary = "프로필 수정", description = "닉네임 변경")
 	@PatchMapping("/me")
 	public ApiResponse<MemberResponse> updateProfile(
-		@AuthenticationPrincipal CustomOAuth2User principal,
-		@Valid @RequestBody UpdateProfileRequest request) {
-		MemberResponse response = memberService.updateProfile(principal.getUserId(), request);
+			@AuthenticationPrincipal JwtAuthentication principal,
+			@Valid @RequestBody UpdateProfileRequest request) {
+		MemberResponse response = memberService.updateProfile(principal.userId(), request);
 		return ApiResponse.success(SuccessCode.UPDATED, response);
 	}
 
 	@Operation(summary = "회원 탈퇴", description = "계정 비활성화 (Soft Delete)")
 	@DeleteMapping("/me")
 	public ApiResponse<Void> withdraw(
-		@AuthenticationPrincipal CustomOAuth2User principal) {
-		memberService.withdraw(principal.getUserId());
+			@AuthenticationPrincipal JwtAuthentication principal) {
+		memberService.withdraw(principal.userId());
 		return ApiResponse.success(SuccessCode.DELETED);
 	}
 }

--- a/src/main/java/com/pace/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/MemberController.java
@@ -1,0 +1,59 @@
+package com.pace.server.domain.member.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.member.dto.request.UpdateProfileRequest;
+import com.pace.server.domain.member.dto.response.MemberResponse;
+import com.pace.server.domain.member.service.MemberService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.oauth2.CustomOAuth2User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 회원 API 컨트롤러.
+ * 프로필 조회/수정, 회원 탈퇴.
+ */
+@Tag(name = "Member", description = "회원 API")
+@RestController
+@RequestMapping("/api/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @Operation(summary = "내 프로필 조회")
+    @GetMapping("/me")
+    public ApiResponse<MemberResponse> getMyProfile(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+        MemberResponse response = memberService.getProfile(principal.getUserId());
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "프로필 수정", description = "닉네임 변경")
+    @PatchMapping("/me")
+    public ApiResponse<MemberResponse> updateProfile(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @Valid @RequestBody UpdateProfileRequest request) {
+        MemberResponse response = memberService.updateProfile(principal.getUserId(), request);
+        return ApiResponse.success(SuccessCode.UPDATED, response);
+    }
+
+    @Operation(summary = "회원 탈퇴", description = "계정 비활성화 (Soft Delete)")
+    @DeleteMapping("/me")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+        memberService.withdraw(principal.getUserId());
+        return ApiResponse.success(SuccessCode.DELETED);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/controller/MemberController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/MemberController.java
@@ -30,30 +30,30 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 
-    private final MemberService memberService;
+	private final MemberService memberService;
 
-    @Operation(summary = "내 프로필 조회")
-    @GetMapping("/me")
-    public ApiResponse<MemberResponse> getMyProfile(
-            @AuthenticationPrincipal CustomOAuth2User principal) {
-        MemberResponse response = memberService.getProfile(principal.getUserId());
-        return ApiResponse.ok(response);
-    }
+	@Operation(summary = "내 프로필 조회")
+	@GetMapping("/me")
+	public ApiResponse<MemberResponse> getMyProfile(
+		@AuthenticationPrincipal CustomOAuth2User principal) {
+		MemberResponse response = memberService.getProfile(principal.getUserId());
+		return ApiResponse.ok(response);
+	}
 
-    @Operation(summary = "프로필 수정", description = "닉네임 변경")
-    @PatchMapping("/me")
-    public ApiResponse<MemberResponse> updateProfile(
-            @AuthenticationPrincipal CustomOAuth2User principal,
-            @Valid @RequestBody UpdateProfileRequest request) {
-        MemberResponse response = memberService.updateProfile(principal.getUserId(), request);
-        return ApiResponse.success(SuccessCode.UPDATED, response);
-    }
+	@Operation(summary = "프로필 수정", description = "닉네임 변경")
+	@PatchMapping("/me")
+	public ApiResponse<MemberResponse> updateProfile(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@Valid @RequestBody UpdateProfileRequest request) {
+		MemberResponse response = memberService.updateProfile(principal.getUserId(), request);
+		return ApiResponse.success(SuccessCode.UPDATED, response);
+	}
 
-    @Operation(summary = "회원 탈퇴", description = "계정 비활성화 (Soft Delete)")
-    @DeleteMapping("/me")
-    public ApiResponse<Void> withdraw(
-            @AuthenticationPrincipal CustomOAuth2User principal) {
-        memberService.withdraw(principal.getUserId());
-        return ApiResponse.success(SuccessCode.DELETED);
-    }
+	@Operation(summary = "회원 탈퇴", description = "계정 비활성화 (Soft Delete)")
+	@DeleteMapping("/me")
+	public ApiResponse<Void> withdraw(
+		@AuthenticationPrincipal CustomOAuth2User principal) {
+		memberService.withdraw(principal.getUserId());
+		return ApiResponse.success(SuccessCode.DELETED);
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
@@ -1,0 +1,50 @@
+package com.pace.server.domain.member.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.member.dto.request.UpdatePreferenceRequest;
+import com.pace.server.domain.member.dto.response.PreferenceResponse;
+import com.pace.server.domain.member.service.PreferenceService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.oauth2.CustomOAuth2User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 사용자 설정 API 컨트롤러.
+ * 지역, 음성 설정, 브리핑 시간 관리.
+ */
+@Tag(name = "Preference", description = "사용자 설정 API")
+@RestController
+@RequestMapping("/api/v1/members/me/preferences")
+@RequiredArgsConstructor
+public class PreferenceController {
+
+    private final PreferenceService preferenceService;
+
+    @Operation(summary = "설정 조회")
+    @GetMapping
+    public ApiResponse<PreferenceResponse> getPreference(
+            @AuthenticationPrincipal CustomOAuth2User principal) {
+        PreferenceResponse response = preferenceService.getPreference(principal.getUserId());
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(summary = "설정 수정", description = "지역, 음성, 브리핑 시간 설정")
+    @PutMapping
+    public ApiResponse<PreferenceResponse> updatePreference(
+            @AuthenticationPrincipal CustomOAuth2User principal,
+            @Valid @RequestBody UpdatePreferenceRequest request) {
+        PreferenceResponse response = preferenceService.updatePreference(principal.getUserId(), request);
+        return ApiResponse.success(SuccessCode.UPDATED, response);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
@@ -29,22 +29,22 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PreferenceController {
 
-    private final PreferenceService preferenceService;
+	private final PreferenceService preferenceService;
 
-    @Operation(summary = "설정 조회")
-    @GetMapping
-    public ApiResponse<PreferenceResponse> getPreference(
-            @AuthenticationPrincipal CustomOAuth2User principal) {
-        PreferenceResponse response = preferenceService.getPreference(principal.getUserId());
-        return ApiResponse.ok(response);
-    }
+	@Operation(summary = "설정 조회")
+	@GetMapping
+	public ApiResponse<PreferenceResponse> getPreference(
+		@AuthenticationPrincipal CustomOAuth2User principal) {
+		PreferenceResponse response = preferenceService.getPreference(principal.getUserId());
+		return ApiResponse.ok(response);
+	}
 
-    @Operation(summary = "설정 수정", description = "지역, 음성, 브리핑 시간 설정")
-    @PutMapping
-    public ApiResponse<PreferenceResponse> updatePreference(
-            @AuthenticationPrincipal CustomOAuth2User principal,
-            @Valid @RequestBody UpdatePreferenceRequest request) {
-        PreferenceResponse response = preferenceService.updatePreference(principal.getUserId(), request);
-        return ApiResponse.success(SuccessCode.UPDATED, response);
-    }
+	@Operation(summary = "설정 수정", description = "지역, 음성, 브리핑 시간 설정")
+	@PutMapping
+	public ApiResponse<PreferenceResponse> updatePreference(
+		@AuthenticationPrincipal CustomOAuth2User principal,
+		@Valid @RequestBody UpdatePreferenceRequest request) {
+		PreferenceResponse response = preferenceService.updatePreference(principal.getUserId(), request);
+		return ApiResponse.success(SuccessCode.UPDATED, response);
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
+++ b/src/main/java/com/pace/server/domain/member/controller/PreferenceController.java
@@ -12,7 +12,7 @@ import com.pace.server.domain.member.dto.response.PreferenceResponse;
 import com.pace.server.domain.member.service.PreferenceService;
 import com.pace.server.global.common.code.SuccessCode;
 import com.pace.server.global.common.response.ApiResponse;
-import com.pace.server.global.security.oauth2.CustomOAuth2User;
+import com.pace.server.global.security.jwt.JwtAuthentication;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -34,17 +34,17 @@ public class PreferenceController {
 	@Operation(summary = "설정 조회")
 	@GetMapping
 	public ApiResponse<PreferenceResponse> getPreference(
-		@AuthenticationPrincipal CustomOAuth2User principal) {
-		PreferenceResponse response = preferenceService.getPreference(principal.getUserId());
+			@AuthenticationPrincipal JwtAuthentication principal) {
+		PreferenceResponse response = preferenceService.getPreference(principal.userId());
 		return ApiResponse.ok(response);
 	}
 
 	@Operation(summary = "설정 수정", description = "지역, 음성, 브리핑 시간 설정")
 	@PutMapping
 	public ApiResponse<PreferenceResponse> updatePreference(
-		@AuthenticationPrincipal CustomOAuth2User principal,
-		@Valid @RequestBody UpdatePreferenceRequest request) {
-		PreferenceResponse response = preferenceService.updatePreference(principal.getUserId(), request);
+			@AuthenticationPrincipal JwtAuthentication principal,
+			@Valid @RequestBody UpdatePreferenceRequest request) {
+		PreferenceResponse response = preferenceService.updatePreference(principal.userId(), request);
 		return ApiResponse.success(SuccessCode.UPDATED, response);
 	}
 }

--- a/src/main/java/com/pace/server/domain/member/dto/request/AddInterestRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/AddInterestRequest.java
@@ -1,0 +1,16 @@
+package com.pace.server.domain.member.dto.request;
+
+import com.pace.server.domain.member.entity.InterestItem.InterestType;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 관심 항목 추가 요청 DTO
+ */
+public record AddInterestRequest(
+        @NotNull(message = "관심 유형은 필수입니다") InterestType type,
+
+        @NotBlank(message = "관심 항목 값은 필수입니다") @Size(max = 100, message = "관심 항목 값은 100자 이하여야 합니다") String value) {
+}

--- a/src/main/java/com/pace/server/domain/member/dto/request/AddInterestRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/AddInterestRequest.java
@@ -10,7 +10,7 @@ import jakarta.validation.constraints.Size;
  * 관심 항목 추가 요청 DTO
  */
 public record AddInterestRequest(
-        @NotNull(message = "관심 유형은 필수입니다") InterestType type,
+	@NotNull(message = "관심 유형은 필수입니다") InterestType type,
 
-        @NotBlank(message = "관심 항목 값은 필수입니다") @Size(max = 100, message = "관심 항목 값은 100자 이하여야 합니다") String value) {
+	@NotBlank(message = "관심 항목 값은 필수입니다") @Size(max = 100, message = "관심 항목 값은 100자 이하여야 합니다") String value) {
 }

--- a/src/main/java/com/pace/server/domain/member/dto/request/UpdatePreferenceRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/UpdatePreferenceRequest.java
@@ -1,0 +1,18 @@
+package com.pace.server.domain.member.dto.request;
+
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 사용자 설정 수정 요청 DTO
+ */
+public record UpdatePreferenceRequest(
+        @Size(max = 10, message = "지역 코드는 10자 이하여야 합니다") String regionCode,
+
+        @Size(max = 50, message = "지역명은 50자 이하여야 합니다") String regionName,
+
+        Boolean voiceEnabled,
+
+        LocalTime targetBriefingTime) {
+}

--- a/src/main/java/com/pace/server/domain/member/dto/request/UpdatePreferenceRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/UpdatePreferenceRequest.java
@@ -8,11 +8,11 @@ import jakarta.validation.constraints.Size;
  * 사용자 설정 수정 요청 DTO
  */
 public record UpdatePreferenceRequest(
-        @Size(max = 10, message = "지역 코드는 10자 이하여야 합니다") String regionCode,
+	@Size(max = 10, message = "지역 코드는 10자 이하여야 합니다") String regionCode,
 
-        @Size(max = 50, message = "지역명은 50자 이하여야 합니다") String regionName,
+	@Size(max = 50, message = "지역명은 50자 이하여야 합니다") String regionName,
 
-        Boolean voiceEnabled,
+	Boolean voiceEnabled,
 
-        LocalTime targetBriefingTime) {
+	LocalTime targetBriefingTime) {
 }

--- a/src/main/java/com/pace/server/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/UpdateProfileRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.Size;
  * 프로필 수정 요청 DTO
  */
 public record UpdateProfileRequest(
-        @Size(min = 2, max = 20, message = "닉네임은 2~20자 이내여야 합니다") String nickname) {
+	@Size(min = 2, max = 20, message = "닉네임은 2~20자 이내여야 합니다") String nickname) {
 }

--- a/src/main/java/com/pace/server/domain/member/dto/request/UpdateProfileRequest.java
+++ b/src/main/java/com/pace/server/domain/member/dto/request/UpdateProfileRequest.java
@@ -1,0 +1,10 @@
+package com.pace.server.domain.member.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+/**
+ * 프로필 수정 요청 DTO
+ */
+public record UpdateProfileRequest(
+        @Size(min = 2, max = 20, message = "닉네임은 2~20자 이내여야 합니다") String nickname) {
+}

--- a/src/main/java/com/pace/server/domain/member/dto/response/InterestResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/InterestResponse.java
@@ -1,0 +1,18 @@
+package com.pace.server.domain.member.dto.response;
+
+import com.pace.server.domain.member.entity.InterestItem;
+
+/**
+ * 관심 항목 응답 DTO
+ */
+public record InterestResponse(
+        Long itemId,
+        String type,
+        String value) {
+    public static InterestResponse from(InterestItem item) {
+        return new InterestResponse(
+                item.getId(),
+                item.getType().name(),
+                item.getValue());
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/dto/response/InterestResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/InterestResponse.java
@@ -6,13 +6,13 @@ import com.pace.server.domain.member.entity.InterestItem;
  * 관심 항목 응답 DTO
  */
 public record InterestResponse(
-        Long itemId,
-        String type,
-        String value) {
-    public static InterestResponse from(InterestItem item) {
-        return new InterestResponse(
-                item.getId(),
-                item.getType().name(),
-                item.getValue());
-    }
+	Long itemId,
+	String type,
+	String value) {
+	public static InterestResponse from(InterestItem item) {
+		return new InterestResponse(
+			item.getId(),
+			item.getType().name(),
+			item.getValue());
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,22 @@
+package com.pace.server.domain.member.dto.response;
+
+import com.pace.server.domain.member.entity.User;
+
+/**
+ * 회원 정보 응답 DTO
+ */
+public record MemberResponse(
+        Long userId,
+        String email,
+        String nickname,
+        String provider,
+        String status) {
+    public static MemberResponse from(User user) {
+        return new MemberResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getProvider().name(),
+                user.getStatus().name());
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/MemberResponse.java
@@ -6,17 +6,17 @@ import com.pace.server.domain.member.entity.User;
  * 회원 정보 응답 DTO
  */
 public record MemberResponse(
-        Long userId,
-        String email,
-        String nickname,
-        String provider,
-        String status) {
-    public static MemberResponse from(User user) {
-        return new MemberResponse(
-                user.getId(),
-                user.getEmail(),
-                user.getNickname(),
-                user.getProvider().name(),
-                user.getStatus().name());
-    }
+	Long userId,
+	String email,
+	String nickname,
+	String provider,
+	String status) {
+	public static MemberResponse from(User user) {
+		return new MemberResponse(
+			user.getId(),
+			user.getEmail(),
+			user.getNickname(),
+			user.getProvider().name(),
+			user.getStatus().name());
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/PreferenceResponse.java
@@ -1,0 +1,24 @@
+package com.pace.server.domain.member.dto.response;
+
+import java.time.LocalTime;
+
+import com.pace.server.domain.member.entity.UserPreference;
+
+/**
+ * 사용자 설정 응답 DTO
+ */
+public record PreferenceResponse(
+        Long prefId,
+        String regionCode,
+        String regionName,
+        boolean voiceEnabled,
+        LocalTime targetBriefingTime) {
+    public static PreferenceResponse from(UserPreference pref) {
+        return new PreferenceResponse(
+                pref.getId(),
+                pref.getRegionCode(),
+                pref.getRegionName(),
+                pref.isVoiceEnabled(),
+                pref.getTargetBriefingTime());
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/dto/response/PreferenceResponse.java
+++ b/src/main/java/com/pace/server/domain/member/dto/response/PreferenceResponse.java
@@ -8,17 +8,17 @@ import com.pace.server.domain.member.entity.UserPreference;
  * 사용자 설정 응답 DTO
  */
 public record PreferenceResponse(
-        Long prefId,
-        String regionCode,
-        String regionName,
-        boolean voiceEnabled,
-        LocalTime targetBriefingTime) {
-    public static PreferenceResponse from(UserPreference pref) {
-        return new PreferenceResponse(
-                pref.getId(),
-                pref.getRegionCode(),
-                pref.getRegionName(),
-                pref.isVoiceEnabled(),
-                pref.getTargetBriefingTime());
-    }
+	Long prefId,
+	String regionCode,
+	String regionName,
+	boolean voiceEnabled,
+	LocalTime targetBriefingTime) {
+	public static PreferenceResponse from(UserPreference pref) {
+		return new PreferenceResponse(
+			pref.getId(),
+			pref.getRegionCode(),
+			pref.getRegionName(),
+			pref.isVoiceEnabled(),
+			pref.getTargetBriefingTime());
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/entity/UserPreference.java
+++ b/src/main/java/com/pace/server/domain/member/entity/UserPreference.java
@@ -58,4 +58,8 @@ public class UserPreference extends BaseEntity {
 	public void toggleVoice(boolean enabled) {
 		this.voiceEnabled = enabled;
 	}
+
+	public void updateBriefingTime(LocalTime briefingTime) {
+		this.targetBriefingTime = briefingTime;
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/service/InterestService.java
+++ b/src/main/java/com/pace/server/domain/member/service/InterestService.java
@@ -1,0 +1,87 @@
+package com.pace.server.domain.member.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.dto.request.AddInterestRequest;
+import com.pace.server.domain.member.dto.response.InterestResponse;
+import com.pace.server.domain.member.entity.InterestItem;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.InterestItemRepository;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 관심 항목 서비스.
+ * 뉴스 키워드, 주식 종목, 코인 등 관심사 관리.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InterestService {
+
+    private static final int MAX_INTEREST_ITEMS = 20;
+
+    private final InterestItemRepository interestItemRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 관심 항목 목록 조회
+     */
+    public List<InterestResponse> getInterests(Long userId) {
+        return interestItemRepository.findByUserId(userId)
+                .stream()
+                .map(InterestResponse::from)
+                .toList();
+    }
+
+    /**
+     * 관심 항목 추가
+     */
+    @Transactional
+    public InterestResponse addInterest(Long userId, AddInterestRequest request) {
+        // 개수 제한 체크
+        long currentCount = interestItemRepository.findByUserId(userId).size();
+        if (currentCount >= MAX_INTEREST_ITEMS) {
+            throw new BusinessException(ErrorCode.BAD_REQUEST, "관심 항목은 최대 " + MAX_INTEREST_ITEMS + "개까지 등록할 수 있습니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        InterestItem item = InterestItem.builder()
+                .user(user)
+                .type(request.type())
+                .value(request.value())
+                .build();
+
+        InterestItem saved = interestItemRepository.save(item);
+        log.info("Interest added for user {}: {} - {}", userId, request.type(), request.value());
+
+        return InterestResponse.from(saved);
+    }
+
+    /**
+     * 관심 항목 삭제
+     */
+    @Transactional
+    public void deleteInterest(Long userId, Long itemId) {
+        InterestItem item = interestItemRepository.findById(itemId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+
+        // 본인 소유 확인
+        if (!item.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        interestItemRepository.delete(item);
+        log.info("Interest deleted for user {}: itemId={}", userId, itemId);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/service/InterestService.java
+++ b/src/main/java/com/pace/server/domain/member/service/InterestService.java
@@ -27,61 +27,61 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class InterestService {
 
-    private static final int MAX_INTEREST_ITEMS = 20;
+	private static final int MAX_INTEREST_ITEMS = 20;
 
-    private final InterestItemRepository interestItemRepository;
-    private final UserRepository userRepository;
+	private final InterestItemRepository interestItemRepository;
+	private final UserRepository userRepository;
 
-    /**
-     * 관심 항목 목록 조회
-     */
-    public List<InterestResponse> getInterests(Long userId) {
-        return interestItemRepository.findByUserId(userId)
-                .stream()
-                .map(InterestResponse::from)
-                .toList();
-    }
+	/**
+	 * 관심 항목 목록 조회
+	 */
+	public List<InterestResponse> getInterests(Long userId) {
+		return interestItemRepository.findByUserId(userId)
+			.stream()
+			.map(InterestResponse::from)
+			.toList();
+	}
 
-    /**
-     * 관심 항목 추가
-     */
-    @Transactional
-    public InterestResponse addInterest(Long userId, AddInterestRequest request) {
-        // 개수 제한 체크
-        long currentCount = interestItemRepository.findByUserId(userId).size();
-        if (currentCount >= MAX_INTEREST_ITEMS) {
-            throw new BusinessException(ErrorCode.BAD_REQUEST, "관심 항목은 최대 " + MAX_INTEREST_ITEMS + "개까지 등록할 수 있습니다.");
-        }
+	/**
+	 * 관심 항목 추가
+	 */
+	@Transactional
+	public InterestResponse addInterest(Long userId, AddInterestRequest request) {
+		// 개수 제한 체크
+		long currentCount = interestItemRepository.findByUserId(userId).size();
+		if (currentCount >= MAX_INTEREST_ITEMS) {
+			throw new BusinessException(ErrorCode.BAD_REQUEST, "관심 항목은 최대 " + MAX_INTEREST_ITEMS + "개까지 등록할 수 있습니다.");
+		}
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        InterestItem item = InterestItem.builder()
-                .user(user)
-                .type(request.type())
-                .value(request.value())
-                .build();
+		InterestItem item = InterestItem.builder()
+			.user(user)
+			.type(request.type())
+			.value(request.value())
+			.build();
 
-        InterestItem saved = interestItemRepository.save(item);
-        log.info("Interest added for user {}: {} - {}", userId, request.type(), request.value());
+		InterestItem saved = interestItemRepository.save(item);
+		log.info("Interest added for user {}: {} - {}", userId, request.type(), request.value());
 
-        return InterestResponse.from(saved);
-    }
+		return InterestResponse.from(saved);
+	}
 
-    /**
-     * 관심 항목 삭제
-     */
-    @Transactional
-    public void deleteInterest(Long userId, Long itemId) {
-        InterestItem item = interestItemRepository.findById(itemId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+	/**
+	 * 관심 항목 삭제
+	 */
+	@Transactional
+	public void deleteInterest(Long userId, Long itemId) {
+		InterestItem item = interestItemRepository.findById(itemId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
 
-        // 본인 소유 확인
-        if (!item.getUser().getId().equals(userId)) {
-            throw new BusinessException(ErrorCode.ACCESS_DENIED);
-        }
+		// 본인 소유 확인
+		if (!item.getUser().getId().equals(userId)) {
+			throw new BusinessException(ErrorCode.ACCESS_DENIED);
+		}
 
-        interestItemRepository.delete(item);
-        log.info("Interest deleted for user {}: itemId={}", userId, itemId);
-    }
+		interestItemRepository.delete(item);
+		log.info("Interest deleted for user {}: itemId={}", userId, itemId);
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/pace/server/domain/member/service/MemberService.java
@@ -1,0 +1,66 @@
+package com.pace.server.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.dto.request.UpdateProfileRequest;
+import com.pace.server.domain.member.dto.response.MemberResponse;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 회원 서비스.
+ * 프로필 조회/수정, 회원 탈퇴 관련 비즈니스 로직.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 내 프로필 조회
+     */
+    public MemberResponse getProfile(Long userId) {
+        User user = findActiveUserById(userId);
+        return MemberResponse.from(user);
+    }
+
+    /**
+     * 프로필 수정 (닉네임)
+     */
+    @Transactional
+    public MemberResponse updateProfile(Long userId, UpdateProfileRequest request) {
+        User user = findActiveUserById(userId);
+
+        if (request.nickname() != null) {
+            user.updateNickname(request.nickname());
+        }
+
+        log.info("Profile updated for user: {}", userId);
+        return MemberResponse.from(user);
+    }
+
+    /**
+     * 회원 탈퇴 (Soft Delete)
+     */
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = findActiveUserById(userId);
+        user.deactivate();
+        log.info("User withdrawn: {}", userId);
+    }
+
+    private User findActiveUserById(Long userId) {
+        return userRepository.findById(userId)
+                .filter(User::isActive)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/service/MemberService.java
+++ b/src/main/java/com/pace/server/domain/member/service/MemberService.java
@@ -23,44 +23,44 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class MemberService {
 
-    private final UserRepository userRepository;
+	private final UserRepository userRepository;
 
-    /**
-     * 내 프로필 조회
-     */
-    public MemberResponse getProfile(Long userId) {
-        User user = findActiveUserById(userId);
-        return MemberResponse.from(user);
-    }
+	/**
+	 * 내 프로필 조회
+	 */
+	public MemberResponse getProfile(Long userId) {
+		User user = findActiveUserById(userId);
+		return MemberResponse.from(user);
+	}
 
-    /**
-     * 프로필 수정 (닉네임)
-     */
-    @Transactional
-    public MemberResponse updateProfile(Long userId, UpdateProfileRequest request) {
-        User user = findActiveUserById(userId);
+	/**
+	 * 프로필 수정 (닉네임)
+	 */
+	@Transactional
+	public MemberResponse updateProfile(Long userId, UpdateProfileRequest request) {
+		User user = findActiveUserById(userId);
 
-        if (request.nickname() != null) {
-            user.updateNickname(request.nickname());
-        }
+		if (request.nickname() != null) {
+			user.updateNickname(request.nickname());
+		}
 
-        log.info("Profile updated for user: {}", userId);
-        return MemberResponse.from(user);
-    }
+		log.info("Profile updated for user: {}", userId);
+		return MemberResponse.from(user);
+	}
 
-    /**
-     * 회원 탈퇴 (Soft Delete)
-     */
-    @Transactional
-    public void withdraw(Long userId) {
-        User user = findActiveUserById(userId);
-        user.deactivate();
-        log.info("User withdrawn: {}", userId);
-    }
+	/**
+	 * 회원 탈퇴 (Soft Delete)
+	 */
+	@Transactional
+	public void withdraw(Long userId) {
+		User user = findActiveUserById(userId);
+		user.deactivate();
+		log.info("User withdrawn: {}", userId);
+	}
 
-    private User findActiveUserById(Long userId) {
-        return userRepository.findById(userId)
-                .filter(User::isActive)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-    }
+	private User findActiveUserById(Long userId) {
+		return userRepository.findById(userId)
+			.filter(User::isActive)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+	}
 }

--- a/src/main/java/com/pace/server/domain/member/service/PreferenceService.java
+++ b/src/main/java/com/pace/server/domain/member/service/PreferenceService.java
@@ -1,0 +1,77 @@
+package com.pace.server.domain.member.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.dto.request.UpdatePreferenceRequest;
+import com.pace.server.domain.member.dto.response.PreferenceResponse;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserPreference;
+import com.pace.server.domain.member.repository.UserPreferenceRepository;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 사용자 설정 서비스.
+ * 지역, 음성 설정, 브리핑 시간 관리.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PreferenceService {
+
+    private final UserPreferenceRepository preferenceRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 설정 조회 (없으면 기본값 생성)
+     */
+    public PreferenceResponse getPreference(Long userId) {
+        UserPreference pref = findOrCreate(userId);
+        return PreferenceResponse.from(pref);
+    }
+
+    /**
+     * 설정 수정
+     */
+    @Transactional
+    public PreferenceResponse updatePreference(Long userId, UpdatePreferenceRequest request) {
+        UserPreference pref = findOrCreate(userId);
+
+        if (request.regionCode() != null && request.regionName() != null) {
+            pref.updateRegion(request.regionCode(), request.regionName());
+        }
+        if (request.voiceEnabled() != null) {
+            pref.toggleVoice(request.voiceEnabled());
+        }
+        if (request.targetBriefingTime() != null) {
+            pref.updateBriefingTime(request.targetBriefingTime());
+        }
+
+        log.info("Preference updated for user: {}", userId);
+        return PreferenceResponse.from(pref);
+    }
+
+    private UserPreference findOrCreate(Long userId) {
+        return preferenceRepository.findByUserId(userId)
+                .orElseGet(() -> createDefault(userId));
+    }
+
+    @Transactional
+    protected UserPreference createDefault(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        UserPreference pref = UserPreference.builder()
+                .user(user)
+                .voiceEnabled(true)
+                .build();
+
+        return preferenceRepository.save(pref);
+    }
+}

--- a/src/main/java/com/pace/server/domain/member/service/PreferenceService.java
+++ b/src/main/java/com/pace/server/domain/member/service/PreferenceService.java
@@ -25,53 +25,53 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class PreferenceService {
 
-    private final UserPreferenceRepository preferenceRepository;
-    private final UserRepository userRepository;
+	private final UserPreferenceRepository preferenceRepository;
+	private final UserRepository userRepository;
 
-    /**
-     * 설정 조회 (없으면 기본값 생성)
-     */
-    public PreferenceResponse getPreference(Long userId) {
-        UserPreference pref = findOrCreate(userId);
-        return PreferenceResponse.from(pref);
-    }
+	/**
+	 * 설정 조회 (없으면 기본값 생성)
+	 */
+	public PreferenceResponse getPreference(Long userId) {
+		UserPreference pref = findOrCreate(userId);
+		return PreferenceResponse.from(pref);
+	}
 
-    /**
-     * 설정 수정
-     */
-    @Transactional
-    public PreferenceResponse updatePreference(Long userId, UpdatePreferenceRequest request) {
-        UserPreference pref = findOrCreate(userId);
+	/**
+	 * 설정 수정
+	 */
+	@Transactional
+	public PreferenceResponse updatePreference(Long userId, UpdatePreferenceRequest request) {
+		UserPreference pref = findOrCreate(userId);
 
-        if (request.regionCode() != null && request.regionName() != null) {
-            pref.updateRegion(request.regionCode(), request.regionName());
-        }
-        if (request.voiceEnabled() != null) {
-            pref.toggleVoice(request.voiceEnabled());
-        }
-        if (request.targetBriefingTime() != null) {
-            pref.updateBriefingTime(request.targetBriefingTime());
-        }
+		if (request.regionCode() != null && request.regionName() != null) {
+			pref.updateRegion(request.regionCode(), request.regionName());
+		}
+		if (request.voiceEnabled() != null) {
+			pref.toggleVoice(request.voiceEnabled());
+		}
+		if (request.targetBriefingTime() != null) {
+			pref.updateBriefingTime(request.targetBriefingTime());
+		}
 
-        log.info("Preference updated for user: {}", userId);
-        return PreferenceResponse.from(pref);
-    }
+		log.info("Preference updated for user: {}", userId);
+		return PreferenceResponse.from(pref);
+	}
 
-    private UserPreference findOrCreate(Long userId) {
-        return preferenceRepository.findByUserId(userId)
-                .orElseGet(() -> createDefault(userId));
-    }
+	private UserPreference findOrCreate(Long userId) {
+		return preferenceRepository.findByUserId(userId)
+			.orElseGet(() -> createDefault(userId));
+	}
 
-    @Transactional
-    protected UserPreference createDefault(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+	@Transactional
+	protected UserPreference createDefault(Long userId) {
+		User user = userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        UserPreference pref = UserPreference.builder()
-                .user(user)
-                .voiceEnabled(true)
-                .build();
+		UserPreference pref = UserPreference.builder()
+			.user(user)
+			.voiceEnabled(true)
+			.build();
 
-        return preferenceRepository.save(pref);
-    }
+		return preferenceRepository.save(pref);
+	}
 }

--- a/src/main/java/com/pace/server/global/security/SecurityConfig.java
+++ b/src/main/java/com/pace/server/global/security/SecurityConfig.java
@@ -27,34 +27,34 @@ public class SecurityConfig {
 
 	// 인증 없이 접근 가능한 경로
 	private static final String[] PUBLIC_PATHS = {
-		"/",
-		"/health",
-		"/error",
-		"/favicon.ico"
+			"/",
+			"/health",
+			"/error",
+			"/favicon.ico"
 	};
 	// Swagger 관련 경로
 	private static final String[] SWAGGER_PATHS = {
-		"/swagger-ui.html",
-		"/swagger-ui/**",
-		"/v3/api-docs",
-		"/v3/api-docs/**",
-		"/swagger-resources/**",
-		"/webjars/**"
+			"/swagger-ui.html",
+			"/swagger-ui/**",
+			"/v3/api-docs",
+			"/v3/api-docs/**",
+			"/swagger-resources/**",
+			"/webjars/**"
 	};
-	// 인증 관련 경로
+	// 인증 관련 경로 (공개)
 	private static final String[] AUTH_PATHS = {
-		"/api/auth/**",
-		"/login/**",
-		"/oauth2/**"
+			"/api/v1/auth/reissue", // 토큰 재발급만 공개 (logout은 인증 필요)
+			"/login/**",
+			"/oauth2/**"
 	};
 	// Actuator 경로
 	private static final String[] ACTUATOR_PATHS = {
-		"/actuator/**"
+			"/actuator/**"
 	};
 	// H2 Console 경로
 	private static final String[] H2_PATHS = {
-		"/h2-console",
-		"/h2-console/**"
+			"/h2-console",
+			"/h2-console/**"
 	};
 	private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
@@ -69,49 +69,49 @@ public class SecurityConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return (web) -> web.ignoring()
-			.requestMatchers("/h2-console/**")
-			.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
-				"/webjars/**");
+				.requestMatchers("/h2-console/**")
+				.requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**",
+						"/webjars/**");
 	}
 
 	@Bean
 	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 		return http
-			// CSRF 비활성화 (JWT 사용)
-			.csrf(AbstractHttpConfigurer::disable)
+				// CSRF 비활성화 (JWT 사용)
+				.csrf(AbstractHttpConfigurer::disable)
 
-			// 세션 사용 안함 (Stateless)
-			.sessionManagement(session -> session
-				.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				// 세션 사용 안함 (Stateless)
+				.sessionManagement(session -> session
+						.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-			// H2 Console iframe 허용
-			.headers(headers -> headers.frameOptions(frame -> frame.disable()))
+				// H2 Console iframe 허용
+				.headers(headers -> headers.frameOptions(frame -> frame.disable()))
 
-			// 경로별 인가 설정
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(PUBLIC_PATHS).permitAll()
-				.requestMatchers(SWAGGER_PATHS).permitAll()
-				.requestMatchers(AUTH_PATHS).permitAll()
-				.requestMatchers(ACTUATOR_PATHS).permitAll()
-				.requestMatchers(H2_PATHS).permitAll()
-				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-				.anyRequest().authenticated())
+				// 경로별 인가 설정
+				.authorizeHttpRequests(auth -> auth
+						.requestMatchers(PUBLIC_PATHS).permitAll()
+						.requestMatchers(SWAGGER_PATHS).permitAll()
+						.requestMatchers(AUTH_PATHS).permitAll()
+						.requestMatchers(ACTUATOR_PATHS).permitAll()
+						.requestMatchers(H2_PATHS).permitAll()
+						.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+						.anyRequest().authenticated())
 
-			// OAuth2 로그인 설정
-			.oauth2Login(oauth2 -> oauth2
-				.userInfoEndpoint(userInfo -> userInfo
-					.userService(customOAuth2UserService))
-				.successHandler(oAuth2AuthenticationSuccessHandler)
-				.failureHandler(oAuth2AuthenticationFailureHandler))
+				// OAuth2 로그인 설정
+				.oauth2Login(oauth2 -> oauth2
+						.userInfoEndpoint(userInfo -> userInfo
+								.userService(customOAuth2UserService))
+						.successHandler(oAuth2AuthenticationSuccessHandler)
+						.failureHandler(oAuth2AuthenticationFailureHandler))
 
-			// 예외 핸들러
-			.exceptionHandling(exception -> exception
-				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-				.accessDeniedHandler(jwtAccessDeniedHandler))
+				// 예외 핸들러
+				.exceptionHandling(exception -> exception
+						.authenticationEntryPoint(jwtAuthenticationEntryPoint)
+						.accessDeniedHandler(jwtAccessDeniedHandler))
 
-			// JWT 필터 추가
-			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+				// JWT 필터 추가
+				.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
-			.build();
+				.build();
 	}
 }

--- a/src/test/java/com/pace/server/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/pace/server/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,117 @@
+package com.pace.server.domain.auth.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import com.pace.server.domain.auth.dto.ReissueRequest;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.global.security.handler.RefreshTokenStore;
+import com.pace.server.support.IntegrationTestSupport;
+
+/**
+ * Auth API 통합 테스트
+ */
+class AuthControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private RefreshTokenStore refreshTokenStore;
+
+    private User testUser;
+    private String accessToken;
+    private String refreshToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+        refreshToken = jwtTokenProvider.createRefreshToken(testUser.getId());
+
+        // Redis에 Refresh Token 저장
+        refreshTokenStore.save(
+                testUser.getId(),
+                refreshToken,
+                jwtTokenProvider.getRefreshTokenExpiry());
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/reissue")
+    class Reissue {
+
+        @Test
+        @DisplayName("성공: 토큰 재발급")
+        void success() throws Exception {
+            ReissueRequest request = new ReissueRequest(refreshToken);
+
+            mockMvc.perform(post("/api/v1/auth/reissue")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("TOKEN_REISSUED"))
+                    .andExpect(jsonPath("$.data.accessToken").isNotEmpty())
+                    .andExpect(jsonPath("$.data.refreshToken").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 Refresh Token")
+        void fail_invalidToken() throws Exception {
+            ReissueRequest request = new ReissueRequest("invalid.refresh.token");
+
+            mockMvc.perform(post("/api/v1/auth/reissue")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("E_TOKEN_INVALID"));
+        }
+
+        @Test
+        @DisplayName("실패: Redis에 저장되지 않은 토큰")
+        void fail_tokenNotInRedis() throws Exception {
+            // given - 새 토큰 생성 (Redis에 저장 안함)
+            String notStoredToken = jwtTokenProvider.createRefreshToken(testUser.getId());
+            // Redis에서 기존 토큰 삭제
+            refreshTokenStore.delete(testUser.getId());
+
+            ReissueRequest request = new ReissueRequest(notStoredToken);
+
+            mockMvc.perform(post("/api/v1/auth/reissue")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.code").value("E_RT_MISMATCH"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/auth/logout")
+    class Logout {
+
+        @Test
+        @DisplayName("성공: 로그아웃")
+        void success() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/logout")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("LOGOUT_SUCCESS"));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 로그아웃")
+        void fail_unauthorized() throws Exception {
+            mockMvc.perform(post("/api/v1/auth/logout"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/pace/server/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,159 @@
+package com.pace.server.domain.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.auth.dto.ReissueRequest;
+import com.pace.server.domain.auth.dto.TokenResponse;
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.AuthException;
+import com.pace.server.global.security.handler.RefreshTokenStore;
+import com.pace.server.global.security.jwt.JwtTokenProvider;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private RefreshTokenStore refreshTokenStore;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private static final String VALID_REFRESH_TOKEN = "valid.refresh.token";
+    private static final String NEW_ACCESS_TOKEN = "new.access.token";
+    private static final String NEW_REFRESH_TOKEN = "new.refresh.token";
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("토큰 재발급")
+    class Reissue {
+
+        @Test
+        @DisplayName("성공: 토큰이 정상적으로 재발급된다")
+        void success() {
+            // given
+            ReissueRequest request = new ReissueRequest(VALID_REFRESH_TOKEN);
+
+            given(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserIdFromToken(VALID_REFRESH_TOKEN)).willReturn(1L);
+            given(refreshTokenStore.matches(1L, VALID_REFRESH_TOKEN)).willReturn(true);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(jwtTokenProvider.createAccessToken(1L, "test@test.com", "ROLE_USER"))
+                    .willReturn(NEW_ACCESS_TOKEN);
+            given(jwtTokenProvider.createRefreshToken(1L)).willReturn(NEW_REFRESH_TOKEN);
+            given(jwtTokenProvider.getRefreshTokenExpiry()).willReturn(604800000L);
+
+            // when
+            TokenResponse response = authService.reissue(request);
+
+            // then
+            assertThat(response.accessToken()).isEqualTo(NEW_ACCESS_TOKEN);
+            assertThat(response.refreshToken()).isEqualTo(NEW_REFRESH_TOKEN);
+            verify(refreshTokenStore).delete(1L);
+            verify(refreshTokenStore).save(eq(1L), eq(NEW_REFRESH_TOKEN), anyLong());
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 Refresh Token")
+        void fail_invalidToken() {
+            // given
+            ReissueRequest request = new ReissueRequest("invalid.token");
+            given(jwtTokenProvider.validateToken("invalid.token")).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(request))
+                    .isInstanceOf(AuthException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.TOKEN_INVALID);
+        }
+
+        @Test
+        @DisplayName("실패: Redis 토큰 불일치")
+        void fail_tokenMismatch() {
+            // given
+            ReissueRequest request = new ReissueRequest(VALID_REFRESH_TOKEN);
+
+            given(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserIdFromToken(VALID_REFRESH_TOKEN)).willReturn(1L);
+            given(refreshTokenStore.matches(1L, VALID_REFRESH_TOKEN)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(request))
+                    .isInstanceOf(AuthException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.REFRESH_TOKEN_MISMATCH);
+        }
+
+        @Test
+        @DisplayName("실패: 비활성화된 사용자")
+        void fail_inactiveUser() {
+            // given
+            User inactiveUser = User.builder()
+                    .id(2L)
+                    .email("inactive@test.com")
+                    .role(Role.ROLE_USER)
+                    .status(UserStatus.INACTIVE)
+                    .build();
+
+            ReissueRequest request = new ReissueRequest(VALID_REFRESH_TOKEN);
+
+            given(jwtTokenProvider.validateToken(VALID_REFRESH_TOKEN)).willReturn(true);
+            given(jwtTokenProvider.getUserIdFromToken(VALID_REFRESH_TOKEN)).willReturn(2L);
+            given(refreshTokenStore.matches(2L, VALID_REFRESH_TOKEN)).willReturn(true);
+            given(userRepository.findById(2L)).willReturn(Optional.of(inactiveUser));
+
+            // when & then
+            assertThatThrownBy(() -> authService.reissue(request))
+                    .isInstanceOf(AuthException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_INACTIVE);
+        }
+    }
+
+    @Nested
+    @DisplayName("로그아웃")
+    class Logout {
+
+        @Test
+        @DisplayName("성공: Refresh Token이 삭제된다")
+        void success() {
+            // when
+            authService.logout(1L);
+
+            // then
+            verify(refreshTokenStore).delete(1L);
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/member/controller/InterestControllerTest.java
+++ b/src/test/java/com/pace/server/domain/member/controller/InterestControllerTest.java
@@ -1,0 +1,161 @@
+package com.pace.server.domain.member.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import com.pace.server.domain.member.dto.request.AddInterestRequest;
+import com.pace.server.domain.member.entity.InterestItem;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.InterestItemRepository;
+import com.pace.server.support.IntegrationTestSupport;
+
+/**
+ * Interest API 통합 테스트
+ */
+class InterestControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private InterestItemRepository interestItemRepository;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/members/me/interests")
+    class GetInterests {
+
+        @Test
+        @DisplayName("성공: 빈 목록 조회")
+        void success_empty() throws Exception {
+            mockMvc.perform(get("/api/v1/members/me/interests")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data").isEmpty());
+        }
+
+        @Test
+        @DisplayName("성공: 관심 항목 목록 조회")
+        void success_withItems() throws Exception {
+            // given
+            interestItemRepository.save(InterestItem.builder()
+                    .user(testUser)
+                    .type(InterestItem.InterestType.KEYWORD)
+                    .value("AI")
+                    .build());
+
+            interestItemRepository.save(InterestItem.builder()
+                    .user(testUser)
+                    .type(InterestItem.InterestType.STOCK)
+                    .value("005930")
+                    .build());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/members/me/interests")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/members/me/interests")
+    class AddInterest {
+
+        @Test
+        @DisplayName("성공: 키워드 추가")
+        void success_keyword() throws Exception {
+            AddInterestRequest request = new AddInterestRequest(
+                    InterestItem.InterestType.KEYWORD, "블록체인");
+
+            mockMvc.perform(post("/api/v1/members/me/interests")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("CREATED"))
+                    .andExpect(jsonPath("$.data.type").value("KEYWORD"))
+                    .andExpect(jsonPath("$.data.value").value("블록체인"));
+        }
+
+        @Test
+        @DisplayName("성공: 주식 종목 추가")
+        void success_stock() throws Exception {
+            AddInterestRequest request = new AddInterestRequest(
+                    InterestItem.InterestType.STOCK, "005930");
+
+            mockMvc.perform(post("/api/v1/members/me/interests")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.type").value("STOCK"))
+                    .andExpect(jsonPath("$.data.value").value("005930"));
+        }
+
+        @Test
+        @DisplayName("실패: 유효성 검사 - 빈 값")
+        void fail_validation() throws Exception {
+            AddInterestRequest request = new AddInterestRequest(
+                    InterestItem.InterestType.KEYWORD, "");
+
+            mockMvc.perform(post("/api/v1/members/me/interests")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/members/me/interests/{itemId}")
+    class DeleteInterest {
+
+        @Test
+        @DisplayName("성공: 관심 항목 삭제")
+        void success() throws Exception {
+            // given
+            InterestItem saved = interestItemRepository.save(InterestItem.builder()
+                    .user(testUser)
+                    .type(InterestItem.InterestType.KEYWORD)
+                    .value("삭제할항목")
+                    .build());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/members/me/interests/{itemId}", saved.getId())
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("DELETED"));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 항목")
+        void fail_notFound() throws Exception {
+            mockMvc.perform(delete("/api/v1/members/me/interests/{itemId}", 99999L)
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isNotFound());
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/pace/server/domain/member/controller/MemberControllerTest.java
@@ -1,0 +1,113 @@
+package com.pace.server.domain.member.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+
+import com.pace.server.domain.member.dto.request.UpdateProfileRequest;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.support.IntegrationTestSupport;
+
+/**
+ * Member API 통합 테스트
+ */
+class MemberControllerTest extends IntegrationTestSupport {
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/members/me")
+    class GetMyProfile {
+
+        @Test
+        @DisplayName("성공: 내 프로필 조회")
+        void success() throws Exception {
+            mockMvc.perform(get("/api/v1/members/me")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.email").value("test@test.com"))
+                    .andExpect(jsonPath("$.data.nickname").value("테스터"));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void fail_unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/members/me"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 토큰")
+        void fail_invalidToken() throws Exception {
+            mockMvc.perform(get("/api/v1/members/me")
+                    .header("Authorization", "Bearer invalid.token.here"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/members/me")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("성공: 닉네임 수정")
+        void success() throws Exception {
+            UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
+
+            mockMvc.perform(patch("/api/v1/members/me")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("UPDATED"))
+                    .andExpect(jsonPath("$.data.nickname").value("새닉네임"));
+        }
+
+        @Test
+        @DisplayName("실패: 닉네임 유효성 검사 (너무 짧음)")
+        void fail_validation() throws Exception {
+            UpdateProfileRequest request = new UpdateProfileRequest("A");
+
+            mockMvc.perform(patch("/api/v1/members/me")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("E_INVALID_INPUT"));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/members/me")
+    class Withdraw {
+
+        @Test
+        @DisplayName("성공: 회원 탈퇴")
+        void success() throws Exception {
+            mockMvc.perform(delete("/api/v1/members/me")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("DELETED"));
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/member/service/InterestServiceTest.java
+++ b/src/test/java/com/pace/server/domain/member/service/InterestServiceTest.java
@@ -1,0 +1,202 @@
+package com.pace.server.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.dto.request.AddInterestRequest;
+import com.pace.server.domain.member.dto.response.InterestResponse;
+import com.pace.server.domain.member.entity.InterestItem;
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.InterestItemRepository;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class InterestServiceTest {
+
+    @InjectMocks
+    private InterestService interestService;
+
+    @Mock
+    private InterestItemRepository interestItemRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private InterestItem testInterest;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        testInterest = InterestItem.builder()
+                .id(1L)
+                .user(testUser)
+                .type(InterestItem.InterestType.KEYWORD)
+                .value("AI")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("관심 항목 조회")
+    class GetInterests {
+
+        @Test
+        @DisplayName("성공: 관심 항목 목록이 조회된다")
+        void success() {
+            // given
+            List<InterestItem> items = List.of(
+                    testInterest,
+                    InterestItem.builder()
+                            .id(2L)
+                            .user(testUser)
+                            .type(InterestItem.InterestType.STOCK)
+                            .value("005930")
+                            .build());
+            given(interestItemRepository.findByUserId(1L)).willReturn(items);
+
+            // when
+            List<InterestResponse> response = interestService.getInterests(1L);
+
+            // then
+            assertThat(response).hasSize(2);
+            assertThat(response.get(0).value()).isEqualTo("AI");
+            assertThat(response.get(1).value()).isEqualTo("005930");
+        }
+
+        @Test
+        @DisplayName("성공: 관심 항목이 없으면 빈 리스트 반환")
+        void success_empty() {
+            // given
+            given(interestItemRepository.findByUserId(1L)).willReturn(List.of());
+
+            // when
+            List<InterestResponse> response = interestService.getInterests(1L);
+
+            // then
+            assertThat(response).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("관심 항목 추가")
+    class AddInterest {
+
+        @Test
+        @DisplayName("성공: 관심 항목이 추가된다")
+        void success() {
+            // given
+            AddInterestRequest request = new AddInterestRequest(
+                    InterestItem.InterestType.KEYWORD, "블록체인");
+            given(interestItemRepository.findByUserId(1L)).willReturn(List.of());
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(interestItemRepository.save(any(InterestItem.class))).willAnswer(invocation -> {
+                InterestItem item = invocation.getArgument(0);
+                return InterestItem.builder()
+                        .id(1L)
+                        .user(item.getUser())
+                        .type(item.getType())
+                        .value(item.getValue())
+                        .build();
+            });
+
+            // when
+            InterestResponse response = interestService.addInterest(1L, request);
+
+            // then
+            assertThat(response.type()).isEqualTo("KEYWORD");
+            assertThat(response.value()).isEqualTo("블록체인");
+        }
+
+        @Test
+        @DisplayName("실패: 최대 개수 초과")
+        void fail_exceedLimit() {
+            // given - 20개의 기존 항목
+            List<InterestItem> existingItems = java.util.stream.IntStream.range(0, 20)
+                    .mapToObj(i -> InterestItem.builder().id((long) i).build())
+                    .toList();
+
+            AddInterestRequest request = new AddInterestRequest(
+                    InterestItem.InterestType.KEYWORD, "새키워드");
+            given(interestItemRepository.findByUserId(1L)).willReturn(existingItems);
+
+            // when & then
+            assertThatThrownBy(() -> interestService.addInterest(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.BAD_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("관심 항목 삭제")
+    class DeleteInterest {
+
+        @Test
+        @DisplayName("성공: 관심 항목이 삭제된다")
+        void success() {
+            // given
+            given(interestItemRepository.findById(1L)).willReturn(Optional.of(testInterest));
+
+            // when
+            interestService.deleteInterest(1L, 1L);
+
+            // then
+            verify(interestItemRepository).delete(testInterest);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 항목")
+        void fail_notFound() {
+            // given
+            given(interestItemRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> interestService.deleteInterest(1L, 999L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RESOURCE_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 다른 사용자의 항목")
+        void fail_accessDenied() {
+            // given
+            User otherUser = User.builder().id(2L).build();
+            InterestItem otherUserItem = InterestItem.builder()
+                    .id(2L)
+                    .user(otherUser)
+                    .type(InterestItem.InterestType.KEYWORD)
+                    .value("other")
+                    .build();
+            given(interestItemRepository.findById(2L)).willReturn(Optional.of(otherUserItem));
+
+            // when & then
+            assertThatThrownBy(() -> interestService.deleteInterest(1L, 2L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/pace/server/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,150 @@
+package com.pace.server.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.dto.request.UpdateProfileRequest;
+import com.pace.server.domain.member.dto.response.MemberResponse;
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @InjectMocks
+    private MemberService memberService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("프로필 조회")
+    class GetProfile {
+
+        @Test
+        @DisplayName("성공: 프로필이 정상적으로 조회된다")
+        void success() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+            // when
+            MemberResponse response = memberService.getProfile(1L);
+
+            // then
+            assertThat(response.userId()).isEqualTo(1L);
+            assertThat(response.email()).isEqualTo("test@test.com");
+            assertThat(response.nickname()).isEqualTo("테스터");
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void fail_userNotFound() {
+            // given
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> memberService.getProfile(999L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패: 비활성화된 사용자")
+        void fail_inactiveUser() {
+            // given
+            User inactiveUser = User.builder()
+                    .id(2L)
+                    .email("inactive@test.com")
+                    .status(UserStatus.INACTIVE)
+                    .build();
+            given(userRepository.findById(2L)).willReturn(Optional.of(inactiveUser));
+
+            // when & then
+            assertThatThrownBy(() -> memberService.getProfile(2L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("프로필 수정")
+    class UpdateProfile {
+
+        @Test
+        @DisplayName("성공: 닉네임이 정상적으로 수정된다")
+        void success() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            UpdateProfileRequest request = new UpdateProfileRequest("새닉네임");
+
+            // when
+            MemberResponse response = memberService.updateProfile(1L, request);
+
+            // then
+            assertThat(response.nickname()).isEqualTo("새닉네임");
+        }
+
+        @Test
+        @DisplayName("성공: null 닉네임 요청 시 변경하지 않음")
+        void success_nullNickname() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            UpdateProfileRequest request = new UpdateProfileRequest(null);
+
+            // when
+            MemberResponse response = memberService.updateProfile(1L, request);
+
+            // then
+            assertThat(response.nickname()).isEqualTo("테스터");
+        }
+    }
+
+    @Nested
+    @DisplayName("회원 탈퇴")
+    class Withdraw {
+
+        @Test
+        @DisplayName("성공: 회원이 비활성화된다")
+        void success() {
+            // given
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+
+            // when
+            memberService.withdraw(1L);
+
+            // then
+            assertThat(testUser.getStatus()).isEqualTo(UserStatus.INACTIVE);
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/member/service/PreferenceServiceTest.java
+++ b/src/test/java/com/pace/server/domain/member/service/PreferenceServiceTest.java
@@ -1,0 +1,158 @@
+package com.pace.server.domain.member.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.dto.request.UpdatePreferenceRequest;
+import com.pace.server.domain.member.dto.response.PreferenceResponse;
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserPreference;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserPreferenceRepository;
+import com.pace.server.domain.member.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PreferenceServiceTest {
+
+    @InjectMocks
+    private PreferenceService preferenceService;
+
+    @Mock
+    private UserPreferenceRepository preferenceRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private UserPreference testPreference;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        testPreference = UserPreference.builder()
+                .id(1L)
+                .user(testUser)
+                .regionCode("1100000000")
+                .regionName("서울특별시")
+                .voiceEnabled(true)
+                .targetBriefingTime(LocalTime.of(7, 0))
+                .build();
+    }
+
+    @Nested
+    @DisplayName("설정 조회")
+    class GetPreference {
+
+        @Test
+        @DisplayName("성공: 기존 설정이 조회된다")
+        void success_existing() {
+            // given
+            given(preferenceRepository.findByUserId(1L)).willReturn(Optional.of(testPreference));
+
+            // when
+            PreferenceResponse response = preferenceService.getPreference(1L);
+
+            // then
+            assertThat(response.prefId()).isEqualTo(1L);
+            assertThat(response.regionCode()).isEqualTo("1100000000");
+            assertThat(response.regionName()).isEqualTo("서울특별시");
+            assertThat(response.voiceEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 설정이 없으면 기본값으로 생성된다")
+        void success_createDefault() {
+            // given
+            given(preferenceRepository.findByUserId(1L)).willReturn(Optional.empty());
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(preferenceRepository.save(any(UserPreference.class))).willAnswer(invocation -> {
+                UserPreference saved = invocation.getArgument(0);
+                return UserPreference.builder()
+                        .id(1L)
+                        .user(saved.getUser())
+                        .voiceEnabled(saved.isVoiceEnabled())
+                        .build();
+            });
+
+            // when
+            PreferenceResponse response = preferenceService.getPreference(1L);
+
+            // then
+            assertThat(response.voiceEnabled()).isTrue();
+            verify(preferenceRepository).save(any(UserPreference.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("설정 수정")
+    class UpdatePreference {
+
+        @Test
+        @DisplayName("성공: 지역 정보가 수정된다")
+        void success_updateRegion() {
+            // given
+            given(preferenceRepository.findByUserId(1L)).willReturn(Optional.of(testPreference));
+            UpdatePreferenceRequest request = new UpdatePreferenceRequest(
+                    "2600000000", "부산광역시", null, null);
+
+            // when
+            PreferenceResponse response = preferenceService.updatePreference(1L, request);
+
+            // then
+            assertThat(response.regionCode()).isEqualTo("2600000000");
+            assertThat(response.regionName()).isEqualTo("부산광역시");
+        }
+
+        @Test
+        @DisplayName("성공: 음성 설정이 수정된다")
+        void success_updateVoice() {
+            // given
+            given(preferenceRepository.findByUserId(1L)).willReturn(Optional.of(testPreference));
+            UpdatePreferenceRequest request = new UpdatePreferenceRequest(
+                    null, null, false, null);
+
+            // when
+            PreferenceResponse response = preferenceService.updatePreference(1L, request);
+
+            // then
+            assertThat(response.voiceEnabled()).isFalse();
+        }
+
+        @Test
+        @DisplayName("성공: 브리핑 시간이 수정된다")
+        void success_updateBriefingTime() {
+            // given
+            given(preferenceRepository.findByUserId(1L)).willReturn(Optional.of(testPreference));
+            UpdatePreferenceRequest request = new UpdatePreferenceRequest(
+                    null, null, null, LocalTime.of(8, 30));
+
+            // when
+            PreferenceResponse response = preferenceService.updatePreference(1L, request);
+
+            // then
+            assertThat(response.targetBriefingTime()).isEqualTo(LocalTime.of(8, 30));
+        }
+    }
+}

--- a/src/test/java/com/pace/server/global/security/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/pace/server/global/security/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,141 @@
+package com.pace.server.global.security.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * JWT Token Provider 단위 테스트
+ */
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    // 테스트용 Secret (Base64 인코딩된 64바이트 이상)
+    private static final String TEST_SECRET = "cGFjZS13YWtlLXVsdHJhLXNlY3VyZS1qd3Qtc2VjcmV0LWtleS0yMDI2LXByb2R1Y3Rpb24tZW52aXJvbm1lbnQ=";
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(
+                TEST_SECRET,
+                3600000L, // 1시간
+                604800000L // 7일
+        );
+    }
+
+    @Nested
+    @DisplayName("Access Token 생성")
+    class CreateAccessToken {
+
+        @Test
+        @DisplayName("성공: Access Token이 정상적으로 생성된다")
+        void success() {
+            // given
+            Long userId = 1L;
+            String email = "test@test.com";
+            String role = "ROLE_USER";
+
+            // when
+            String token = jwtTokenProvider.createAccessToken(userId, email, role);
+
+            // then
+            assertThat(token).isNotBlank();
+            assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 토큰에서 userId를 추출할 수 있다")
+        void extractUserId() {
+            // given
+            Long userId = 123L;
+            String token = jwtTokenProvider.createAccessToken(userId, "test@test.com", "ROLE_USER");
+
+            // when
+            Long extractedId = jwtTokenProvider.getUserIdFromToken(token);
+
+            // then
+            assertThat(extractedId).isEqualTo(userId);
+        }
+
+        @Test
+        @DisplayName("성공: 토큰에서 email을 추출할 수 있다")
+        void extractEmail() {
+            // given
+            String email = "user@example.com";
+            String token = jwtTokenProvider.createAccessToken(1L, email, "ROLE_USER");
+
+            // when
+            String extractedEmail = jwtTokenProvider.getEmailFromToken(token);
+
+            // then
+            assertThat(extractedEmail).isEqualTo(email);
+        }
+    }
+
+    @Nested
+    @DisplayName("Refresh Token 생성")
+    class CreateRefreshToken {
+
+        @Test
+        @DisplayName("성공: Refresh Token이 정상적으로 생성된다")
+        void success() {
+            // given
+            Long userId = 1L;
+
+            // when
+            String token = jwtTokenProvider.createRefreshToken(userId);
+
+            // then
+            assertThat(token).isNotBlank();
+            assertThat(jwtTokenProvider.validateToken(token)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증")
+    class ValidateToken {
+
+        @Test
+        @DisplayName("실패: 잘못된 형식의 토큰")
+        void fail_malformed() {
+            // given
+            String malformedToken = "malformed.token.here";
+
+            // when
+            boolean result = jwtTokenProvider.validateToken(malformedToken);
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 빈 토큰")
+        void fail_empty() {
+            // when
+            boolean result = jwtTokenProvider.validateToken("");
+
+            // then
+            assertThat(result).isFalse();
+        }
+
+        @Test
+        @DisplayName("실패: 만료된 토큰")
+        void fail_expired() throws InterruptedException {
+            // given - 1ms 만료 토큰 생성
+            JwtTokenProvider shortExpiryProvider = new JwtTokenProvider(
+                    TEST_SECRET,
+                    1L, // 1ms
+                    1L);
+            String token = shortExpiryProvider.createAccessToken(1L, "test@test.com", "ROLE_USER");
+
+            // when - 토큰 만료 대기
+            Thread.sleep(10);
+
+            // then
+            assertThat(shortExpiryProvider.validateToken(token)).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/pace/server/support/IntegrationTestSupport.java
+++ b/src/test/java/com/pace/server/support/IntegrationTestSupport.java
@@ -1,0 +1,86 @@
+package com.pace.server.support;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.global.security.jwt.JwtTokenProvider;
+
+/**
+ * 통합 테스트 베이스 클래스.
+ * Testcontainers를 사용하여 Redis 자동 실행.
+ * H2 인메모리 DB 사용, 트랜잭션 롤백.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestContainersConfig.class)
+@Transactional
+@ActiveProfiles("test")
+public abstract class IntegrationTestSupport {
+
+    protected MockMvc mockMvc;
+
+    @Autowired
+    private WebApplicationContext webApplicationContext;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    protected JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    protected UserRepository userRepository;
+
+    @BeforeEach
+    void setUpMockMvc() {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .build();
+    }
+
+    /**
+     * 테스트용 사용자 생성
+     */
+    protected User createTestUser() {
+        return userRepository.save(User.builder()
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build());
+    }
+
+    /**
+     * 테스트용 JWT Access Token 생성
+     */
+    protected String createAccessToken(User user) {
+        return jwtTokenProvider.createAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole().name());
+    }
+
+    /**
+     * Bearer 토큰 헤더 값
+     */
+    protected String bearerToken(String accessToken) {
+        return "Bearer " + accessToken;
+    }
+}

--- a/src/test/java/com/pace/server/support/TestContainersConfig.java
+++ b/src/test/java/com/pace/server/support/TestContainersConfig.java
@@ -1,0 +1,25 @@
+package com.pace.server.support;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * 통합 테스트용 컨테이너 설정.
+ * Redis 컨테이너를 자동으로 시작/중지.
+ */
+@TestConfiguration(proxyBeanMethods = false)
+public class TestContainersConfig {
+
+    /**
+     * Redis 컨테이너 (테스트 시 자동 시작)
+     */
+    @Bean
+    @ServiceConnection(name = "redis")
+    public GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+                .withExposedPorts(6379);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,38 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+  # H2 인메모리 데이터베이스
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  # JPA 설정
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+    show-sql: true
+
+  # Embedded Redis 대체 - Mock 사용 또는 실제 Redis 연결
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+# JWT 테스트용 설정
+jwt:
+  secret: cGFjZS13YWtlLXVsdHJhLXNlY3VyZS1qd3Qtc2VjcmV0LWtleS0yMDI2LXByb2R1Y3Rpb24tZW52aXJvbm1lbnQ=
+  access-token-expiry: 3600000
+  refresh-token-expiry: 604800000
+
+# 로깅
+logging:
+  level:
+    com.pace.server: DEBUG
+    org.springframework.security: DEBUG


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈 번호를 링크해주세요 (예: closes #123) -->
closes #5 

## 📝 변경 사항
<!-- 주요 변경 내용을 요약해주세요 -->
- Auth 도메인: 토큰 재발급(RTR), 로그아웃 API 구현
- Member 도메인: 프로필/설정/관심항목 CRUD API 구현
- UserPreference 엔티티에 `updateBriefingTime()` 메서드 추가

## 🔍 변경 유형
- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 추가/수정 (test)
- [x] 설정 변경 (chore)

## ✅ 체크리스트
- [x] 로컬에서 빌드 성공 (`./gradlew build`)
- [ ] 테스트 통과 (`./gradlew test`)
- [x] 코드 스타일 준수
- [x] 관련 문서 업데이트 (필요시)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분이 있다면 작성해주세요 -->
