### PR TITLE
feat: Wake Domain API 구현 (Alarm, WakeLog, Todo)

### DIFF
--- a/src/main/java/com/pace/server/domain/wake/controller/AlarmController.java
+++ b/src/main/java/com/pace/server/domain/wake/controller/AlarmController.java
@@ -1,0 +1,80 @@
+package com.pace.server.domain.wake.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.wake.dto.request.CreateAlarmRequest;
+import com.pace.server.domain.wake.dto.request.UpdateAlarmRequest;
+import com.pace.server.domain.wake.dto.response.AlarmResponse;
+import com.pace.server.domain.wake.service.AlarmService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.jwt.JwtAuthentication;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Alarm", description = "알람 API")
+@RestController
+@RequestMapping("/api/v1/alarms")
+@RequiredArgsConstructor
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @Operation(summary = "알람 목록 조회", description = "사용자의 알람 목록을 조회합니다")
+    @GetMapping
+    public ApiResponse<List<AlarmResponse>> getAlarms(
+            @AuthenticationPrincipal JwtAuthentication principal) {
+        return ApiResponse.success(SuccessCode.OK, alarmService.getAlarms(principal.userId()));
+    }
+
+    @Operation(summary = "알람 생성", description = "새 알람을 생성합니다 (최대 10개)")
+    @PostMapping
+    public ApiResponse<AlarmResponse> createAlarm(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @Valid @RequestBody CreateAlarmRequest request) {
+        return ApiResponse.success(SuccessCode.CREATED,
+                alarmService.createAlarm(principal.userId(), request));
+    }
+
+    @Operation(summary = "알람 수정", description = "알람 설정을 수정합니다")
+    @PutMapping("/{id}")
+    public ApiResponse<AlarmResponse> updateAlarm(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateAlarmRequest request) {
+        return ApiResponse.success(SuccessCode.UPDATED,
+                alarmService.updateAlarm(principal.userId(), id, request));
+    }
+
+    @Operation(summary = "알람 토글", description = "알람 활성화/비활성화 상태를 토글합니다")
+    @PatchMapping("/{id}/toggle")
+    public ApiResponse<AlarmResponse> toggleAlarm(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id) {
+        return ApiResponse.success(SuccessCode.OK,
+                alarmService.toggleAlarm(principal.userId(), id));
+    }
+
+    @Operation(summary = "알람 삭제", description = "알람을 삭제합니다")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteAlarm(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id) {
+        alarmService.deleteAlarm(principal.userId(), id);
+        return ApiResponse.success(SuccessCode.DELETED);
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/controller/TodoController.java
+++ b/src/main/java/com/pace/server/domain/wake/controller/TodoController.java
@@ -1,0 +1,77 @@
+package com.pace.server.domain.wake.controller;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.wake.dto.request.CreateTodoRequest;
+import com.pace.server.domain.wake.dto.response.TodoResponse;
+import com.pace.server.domain.wake.service.TodoService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.jwt.JwtAuthentication;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Todo", description = "투두 API")
+@RestController
+@RequestMapping("/api/v1/todos")
+@RequiredArgsConstructor
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @Operation(summary = "오늘 투두 목록 조회", description = "오늘 날짜의 투두 목록을 조회합니다")
+    @GetMapping
+    public ApiResponse<List<TodoResponse>> getTodayTodos(
+            @AuthenticationPrincipal JwtAuthentication principal) {
+        return ApiResponse.success(SuccessCode.OK, todoService.getTodayTodos(principal.userId()));
+    }
+
+    @Operation(summary = "투두 추가", description = "오늘 날짜에 새 투두를 추가합니다")
+    @PostMapping
+    public ApiResponse<TodoResponse> createTodo(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @Valid @RequestBody CreateTodoRequest request) {
+        return ApiResponse.success(SuccessCode.CREATED,
+                todoService.createTodo(principal.userId(), request));
+    }
+
+    @Operation(summary = "투두 완료 토글", description = "투두의 완료 상태를 토글합니다")
+    @PatchMapping("/{id}/toggle")
+    public ApiResponse<TodoResponse> toggleTodo(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id) {
+        return ApiResponse.success(SuccessCode.OK,
+                todoService.toggleTodo(principal.userId(), id));
+    }
+
+    @Operation(summary = "투두 다음날로 미루기", description = "투두를 다음 날로 미룹니다")
+    @PostMapping("/{id}/postpone")
+    public ApiResponse<TodoResponse> postponeTodo(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id) {
+        return ApiResponse.success(SuccessCode.OK,
+                todoService.postponeTodo(principal.userId(), id));
+    }
+
+    @Operation(summary = "투두 삭제", description = "투두를 삭제합니다")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteTodo(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @PathVariable Long id) {
+        todoService.deleteTodo(principal.userId(), id);
+        return ApiResponse.success(SuccessCode.DELETED);
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/controller/WakeController.java
+++ b/src/main/java/com/pace/server/domain/wake/controller/WakeController.java
@@ -1,0 +1,47 @@
+package com.pace.server.domain.wake.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.wake.dto.request.WakeLogRequest;
+import com.pace.server.domain.wake.dto.response.StreakResponse;
+import com.pace.server.domain.wake.dto.response.WakeLogResponse;
+import com.pace.server.domain.wake.service.WakeLogService;
+import com.pace.server.global.common.code.SuccessCode;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.jwt.JwtAuthentication;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Wake", description = "기상 기록 API")
+@RestController
+@RequestMapping("/api/v1/wake")
+@RequiredArgsConstructor
+public class WakeController {
+
+    private final WakeLogService wakeLogService;
+
+    @Operation(summary = "기상 로그 기록", description = "미션 완료 후 기상 로그를 기록합니다")
+    @PostMapping("/log")
+    public ApiResponse<WakeLogResponse> recordWakeLog(
+            @AuthenticationPrincipal JwtAuthentication principal,
+            @Valid @RequestBody WakeLogRequest request) {
+        return ApiResponse.success(SuccessCode.CREATED,
+                wakeLogService.recordWakeLog(principal.userId(), request));
+    }
+
+    @Operation(summary = "연속 기상 스트릭 조회", description = "연속 기상 일수 및 통계를 조회합니다")
+    @GetMapping("/streak")
+    public ApiResponse<StreakResponse> getStreak(
+            @AuthenticationPrincipal JwtAuthentication principal) {
+        return ApiResponse.success(SuccessCode.OK,
+                wakeLogService.getStreak(principal.userId()));
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/request/CreateAlarmRequest.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/request/CreateAlarmRequest.java
@@ -1,0 +1,23 @@
+package com.pace.server.domain.wake.dto.request;
+
+import java.time.LocalTime;
+
+import com.pace.server.domain.wake.entity.MissionType;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record CreateAlarmRequest(
+        @NotNull(message = "기상 시간은 필수입니다") LocalTime wakeTime,
+
+        @NotNull(message = "반복 요일은 필수입니다") @Pattern(regexp = "^[01]{7}$", message = "반복 요일은 7자리 0/1 문자열이어야 합니다 (예: 0111110)") String repeatDays,
+
+        @NotNull(message = "미션 타입은 필수입니다") MissionType missionType,
+
+        @Min(value = 1, message = "미션 레벨은 1 이상이어야 합니다") @Max(value = 5, message = "미션 레벨은 5 이하이어야 합니다") int missionLevel,
+
+        @Size(max = 50, message = "라벨은 최대 50자까지 가능합니다") String label) {
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/request/CreateTodoRequest.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/request/CreateTodoRequest.java
@@ -1,0 +1,8 @@
+package com.pace.server.domain.wake.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateTodoRequest(
+        @NotBlank(message = "투두 내용은 필수입니다") @Size(max = 200, message = "투두 내용은 최대 200자까지 가능합니다") String content) {
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/request/UpdateAlarmRequest.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/request/UpdateAlarmRequest.java
@@ -1,0 +1,23 @@
+package com.pace.server.domain.wake.dto.request;
+
+import java.time.LocalTime;
+
+import com.pace.server.domain.wake.entity.MissionType;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record UpdateAlarmRequest(
+        @NotNull(message = "기상 시간은 필수입니다") LocalTime wakeTime,
+
+        @NotNull(message = "반복 요일은 필수입니다") @Pattern(regexp = "^[01]{7}$", message = "반복 요일은 7자리 0/1 문자열이어야 합니다") String repeatDays,
+
+        @NotNull(message = "미션 타입은 필수입니다") MissionType missionType,
+
+        @Min(value = 1, message = "미션 레벨은 1 이상이어야 합니다") @Max(value = 5, message = "미션 레벨은 5 이하이어야 합니다") int missionLevel,
+
+        @Size(max = 50, message = "라벨은 최대 50자까지 가능합니다") String label) {
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/request/WakeLogRequest.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/request/WakeLogRequest.java
@@ -1,0 +1,14 @@
+package com.pace.server.domain.wake.dto.request;
+
+import java.time.LocalTime;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record WakeLogRequest(
+        @NotNull(message = "기상 시간은 필수입니다") LocalTime wakeTime,
+
+        boolean isSuccess,
+
+        @Min(value = 0, message = "미션 소요 시간은 0 이상이어야 합니다") int durationSeconds) {
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/response/AlarmResponse.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/response/AlarmResponse.java
@@ -1,0 +1,26 @@
+package com.pace.server.domain.wake.dto.response;
+
+import java.time.LocalTime;
+
+import com.pace.server.domain.wake.entity.Alarm;
+import com.pace.server.domain.wake.entity.MissionType;
+
+public record AlarmResponse(
+        Long id,
+        LocalTime wakeTime,
+        String repeatDays,
+        MissionType missionType,
+        int missionLevel,
+        boolean isActive,
+        String label) {
+    public static AlarmResponse from(Alarm alarm) {
+        return new AlarmResponse(
+                alarm.getId(),
+                alarm.getWakeTime(),
+                alarm.getRepeatDays(),
+                alarm.getMissionType(),
+                alarm.getMissionLevel(),
+                alarm.isActive(),
+                alarm.getLabel());
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/response/StreakResponse.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/response/StreakResponse.java
@@ -1,0 +1,7 @@
+package com.pace.server.domain.wake.dto.response;
+
+public record StreakResponse(
+        int currentStreak,
+        int maxStreak,
+        long totalSuccessCount) {
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/response/TodoResponse.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/response/TodoResponse.java
@@ -1,0 +1,21 @@
+package com.pace.server.domain.wake.dto.response;
+
+import java.time.LocalDate;
+
+import com.pace.server.domain.wake.entity.Todo;
+
+public record TodoResponse(
+        Long id,
+        String content,
+        LocalDate targetDate,
+        boolean isDone,
+        int displayOrder) {
+    public static TodoResponse from(Todo todo) {
+        return new TodoResponse(
+                todo.getId(),
+                todo.getContent(),
+                todo.getTargetDate(),
+                todo.isDone(),
+                todo.getDisplayOrder());
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/dto/response/WakeLogResponse.java
+++ b/src/main/java/com/pace/server/domain/wake/dto/response/WakeLogResponse.java
@@ -1,0 +1,25 @@
+package com.pace.server.domain.wake.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import com.pace.server.domain.wake.entity.WakeLog;
+
+public record WakeLogResponse(
+        Long id,
+        LocalDate wakeDate,
+        LocalTime wakeTime,
+        boolean isSuccess,
+        int durationSeconds,
+        LocalDateTime createdAt) {
+    public static WakeLogResponse from(WakeLog wakeLog) {
+        return new WakeLogResponse(
+                wakeLog.getId(),
+                wakeLog.getWakeDate(),
+                wakeLog.getWakeTime(),
+                wakeLog.isSuccess(),
+                wakeLog.getDurationSeconds(),
+                wakeLog.getCreatedAt());
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/repository/WakeLogRepository.java
+++ b/src/main/java/com/pace/server/domain/wake/repository/WakeLogRepository.java
@@ -15,6 +15,10 @@ public interface WakeLogRepository extends JpaRepository<WakeLog, Long> {
 
 	Optional<WakeLog> findByUserIdAndWakeDate(Long userId, LocalDate wakeDate);
 
+	List<WakeLog> findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(Long userId);
+
+	long countByUserIdAndIsSuccessTrue(Long userId);
+
 	@Query("SELECT COUNT(w) FROM WakeLog w WHERE w.user.id = :userId AND w.isSuccess = true AND w.wakeDate >= :startDate")
 	long countSuccessfulWakes(@Param("userId") Long userId, @Param("startDate") LocalDate startDate);
 }

--- a/src/main/java/com/pace/server/domain/wake/service/AlarmService.java
+++ b/src/main/java/com/pace/server/domain/wake/service/AlarmService.java
@@ -1,0 +1,101 @@
+package com.pace.server.domain.wake.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.CreateAlarmRequest;
+import com.pace.server.domain.wake.dto.request.UpdateAlarmRequest;
+import com.pace.server.domain.wake.dto.response.AlarmResponse;
+import com.pace.server.domain.wake.entity.Alarm;
+import com.pace.server.domain.wake.repository.AlarmRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AlarmService {
+
+    private static final int MAX_ALARM_COUNT = 10;
+
+    private final AlarmRepository alarmRepository;
+    private final UserRepository userRepository;
+
+    public List<AlarmResponse> getAlarms(Long userId) {
+        return alarmRepository.findByUserIdOrderByWakeTimeAsc(userId)
+                .stream()
+                .map(AlarmResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public AlarmResponse createAlarm(Long userId, CreateAlarmRequest request) {
+        // 알람 개수 제한 확인
+        if (alarmRepository.countByUserId(userId) >= MAX_ALARM_COUNT) {
+            throw new BusinessException(ErrorCode.ALARM_LIMIT_EXCEEDED);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Alarm alarm = Alarm.builder()
+                .user(user)
+                .wakeTime(request.wakeTime())
+                .repeatDays(request.repeatDays())
+                .missionType(request.missionType())
+                .missionLevel(request.missionLevel())
+                .label(request.label())
+                .isActive(true)
+                .build();
+
+        Alarm saved = alarmRepository.save(alarm);
+        log.info("Alarm created: userId={}, alarmId={}", userId, saved.getId());
+
+        return AlarmResponse.from(saved);
+    }
+
+    @Transactional
+    public AlarmResponse updateAlarm(Long userId, Long alarmId, UpdateAlarmRequest request) {
+        Alarm alarm = findAlarmByIdAndUserId(alarmId, userId);
+
+        alarm.updateSettings(
+                request.wakeTime(),
+                request.repeatDays(),
+                request.missionType(),
+                request.missionLevel());
+
+        if (request.label() != null) {
+            alarm.updateLabel(request.label());
+        }
+
+        return AlarmResponse.from(alarm);
+    }
+
+    @Transactional
+    public AlarmResponse toggleAlarm(Long userId, Long alarmId) {
+        Alarm alarm = findAlarmByIdAndUserId(alarmId, userId);
+        alarm.toggle();
+        return AlarmResponse.from(alarm);
+    }
+
+    @Transactional
+    public void deleteAlarm(Long userId, Long alarmId) {
+        Alarm alarm = findAlarmByIdAndUserId(alarmId, userId);
+        alarmRepository.delete(alarm);
+        log.info("Alarm deleted: userId={}, alarmId={}", userId, alarmId);
+    }
+
+    private Alarm findAlarmByIdAndUserId(Long alarmId, Long userId) {
+        return alarmRepository.findById(alarmId)
+                .filter(a -> a.getUser().getId().equals(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.ALARM_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/service/TodoService.java
+++ b/src/main/java/com/pace/server/domain/wake/service/TodoService.java
@@ -1,0 +1,91 @@
+package com.pace.server.domain.wake.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.CreateTodoRequest;
+import com.pace.server.domain.wake.dto.response.TodoResponse;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TodoService {
+
+    private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
+
+    public List<TodoResponse> getTodayTodos(Long userId) {
+        return todoRepository.findByUserIdAndTargetDateOrderByDisplayOrderAsc(userId, LocalDate.now())
+                .stream()
+                .map(TodoResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public TodoResponse createTodo(Long userId, CreateTodoRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        int nextOrder = (int) todoRepository.countByUserIdAndTargetDate(userId, LocalDate.now());
+
+        Todo todo = Todo.builder()
+                .user(user)
+                .content(request.content())
+                .targetDate(LocalDate.now())
+                .isDone(false)
+                .displayOrder(nextOrder)
+                .build();
+
+        Todo saved = todoRepository.save(todo);
+        log.info("Todo created: userId={}, todoId={}", userId, saved.getId());
+
+        return TodoResponse.from(saved);
+    }
+
+    @Transactional
+    public TodoResponse toggleTodo(Long userId, Long todoId) {
+        Todo todo = findTodoByIdAndUserId(todoId, userId);
+        todo.toggleDone();
+        return TodoResponse.from(todo);
+    }
+
+    @Transactional
+    public TodoResponse postponeTodo(Long userId, Long todoId) {
+        Todo oldTodo = findTodoByIdAndUserId(todoId, userId);
+        Todo newTodo = oldTodo.postponeTo(LocalDate.now().plusDays(1));
+
+        todoRepository.delete(oldTodo);
+        Todo saved = todoRepository.save(newTodo);
+
+        log.info("Todo postponed: userId={}, oldTodoId={}, newTodoId={}",
+                userId, todoId, saved.getId());
+
+        return TodoResponse.from(saved);
+    }
+
+    @Transactional
+    public void deleteTodo(Long userId, Long todoId) {
+        Todo todo = findTodoByIdAndUserId(todoId, userId);
+        todoRepository.delete(todo);
+        log.info("Todo deleted: userId={}, todoId={}", userId, todoId);
+    }
+
+    private Todo findTodoByIdAndUserId(Long todoId, Long userId) {
+        return todoRepository.findById(todoId)
+                .filter(t -> t.getUser().getId().equals(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.RESOURCE_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/pace/server/domain/wake/service/WakeLogService.java
+++ b/src/main/java/com/pace/server/domain/wake/service/WakeLogService.java
@@ -1,0 +1,114 @@
+package com.pace.server.domain.wake.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.WakeLogRequest;
+import com.pace.server.domain.wake.dto.response.StreakResponse;
+import com.pace.server.domain.wake.dto.response.WakeLogResponse;
+import com.pace.server.domain.wake.entity.WakeLog;
+import com.pace.server.domain.wake.repository.WakeLogRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WakeLogService {
+
+    private static final int MIN_MISSION_DURATION = 1; // 최소 1초
+
+    private final WakeLogRepository wakeLogRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public WakeLogResponse recordWakeLog(Long userId, WakeLogRequest request) {
+        // 어뷰징 방지: 미션 시간이 너무 짧은 경우
+        if (request.durationSeconds() < MIN_MISSION_DURATION) {
+            throw new BusinessException(ErrorCode.MISSION_TOO_FAST);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        WakeLog wakeLog = WakeLog.builder()
+                .user(user)
+                .wakeDate(LocalDate.now())
+                .wakeTime(request.wakeTime())
+                .isSuccess(request.isSuccess())
+                .durationSeconds(request.durationSeconds())
+                .build();
+
+        WakeLog saved = wakeLogRepository.save(wakeLog);
+        log.info("Wake log recorded: userId={}, success={}", userId, request.isSuccess());
+
+        return WakeLogResponse.from(saved);
+    }
+
+    public StreakResponse getStreak(Long userId) {
+        List<WakeLog> recentLogs = wakeLogRepository
+                .findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(userId);
+
+        int currentStreak = calculateStreak(recentLogs);
+        int maxStreak = calculateMaxStreak(recentLogs);
+        long totalSuccessCount = wakeLogRepository.countByUserIdAndIsSuccessTrue(userId);
+
+        return new StreakResponse(currentStreak, maxStreak, totalSuccessCount);
+    }
+
+    private int calculateStreak(List<WakeLog> logs) {
+        if (logs.isEmpty()) {
+            return 0;
+        }
+
+        int streak = 0;
+        LocalDate expected = LocalDate.now();
+
+        for (WakeLog wakeLog : logs) {
+            LocalDate logDate = wakeLog.getWakeDate();
+            // 오늘 또는 어제부터 연속으로 카운트
+            if (logDate.equals(expected) || logDate.equals(expected.minusDays(1))) {
+                streak++;
+                expected = logDate.minusDays(1);
+            } else {
+                break;
+            }
+        }
+
+        return streak;
+    }
+
+    private int calculateMaxStreak(List<WakeLog> logs) {
+        if (logs.isEmpty()) {
+            return 0;
+        }
+
+        int maxStreak = 0;
+        int currentStreak = 1;
+        LocalDate prevDate = null;
+
+        for (WakeLog wakeLog : logs) {
+            LocalDate logDate = wakeLog.getWakeDate();
+            if (prevDate != null) {
+                if (prevDate.minusDays(1).equals(logDate)) {
+                    currentStreak++;
+                } else {
+                    maxStreak = Math.max(maxStreak, currentStreak);
+                    currentStreak = 1;
+                }
+            }
+            prevDate = logDate;
+        }
+
+        return Math.max(maxStreak, currentStreak);
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/controller/AlarmControllerTest.java
+++ b/src/test/java/com/pace/server/domain/wake/controller/AlarmControllerTest.java
@@ -1,0 +1,207 @@
+package com.pace.server.domain.wake.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.wake.dto.request.CreateAlarmRequest;
+import com.pace.server.domain.wake.dto.request.UpdateAlarmRequest;
+import com.pace.server.domain.wake.entity.Alarm;
+import com.pace.server.domain.wake.entity.MissionType;
+import com.pace.server.domain.wake.repository.AlarmRepository;
+import com.pace.server.support.IntegrationTestSupport;
+
+class AlarmControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private AlarmRepository alarmRepository;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/alarms")
+    class GetAlarms {
+
+        @Test
+        @DisplayName("성공: 알람 목록 조회")
+        void success() throws Exception {
+            // given
+            alarmRepository.save(Alarm.builder()
+                    .user(testUser)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .repeatDays("0111110")
+                    .missionType(MissionType.MATH)
+                    .missionLevel(2)
+                    .isActive(true)
+                    .build());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/alarms")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].wakeTime").value("07:00:00"));
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void fail_unauthorized() throws Exception {
+            mockMvc.perform(get("/api/v1/alarms"))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/alarms")
+    class CreateAlarm {
+
+        @Test
+        @DisplayName("성공: 알람 생성")
+        void success() throws Exception {
+            // given
+            CreateAlarmRequest request = new CreateAlarmRequest(
+                    LocalTime.of(6, 30),
+                    "1111111",
+                    MissionType.SHAKE,
+                    3,
+                    "출근 알람");
+
+            // when & then
+            mockMvc.perform(post("/api/v1/alarms")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("CREATED"))
+                    .andExpect(jsonPath("$.data.wakeTime").value("06:30:00"))
+                    .andExpect(jsonPath("$.data.missionType").value("SHAKE"));
+        }
+
+        @Test
+        @DisplayName("실패: 유효하지 않은 반복 요일")
+        void fail_invalidRepeatDays() throws Exception {
+            // given
+            CreateAlarmRequest request = new CreateAlarmRequest(
+                    LocalTime.of(6, 30),
+                    "12345", // 잘못된 형식
+                    MissionType.MATH,
+                    1,
+                    null);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/alarms")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /api/v1/alarms/{id}")
+    class UpdateAlarm {
+
+        @Test
+        @DisplayName("성공: 알람 수정")
+        void success() throws Exception {
+            // given
+            Alarm alarm = alarmRepository.save(Alarm.builder()
+                    .user(testUser)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .repeatDays("0111110")
+                    .missionType(MissionType.MATH)
+                    .missionLevel(2)
+                    .build());
+
+            UpdateAlarmRequest request = new UpdateAlarmRequest(
+                    LocalTime.of(8, 0),
+                    "1111111",
+                    MissionType.SQUAT,
+                    4,
+                    "수정된 알람");
+
+            // when & then
+            mockMvc.perform(put("/api/v1/alarms/" + alarm.getId())
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.wakeTime").value("08:00:00"))
+                    .andExpect(jsonPath("$.data.missionType").value("SQUAT"));
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/alarms/{id}/toggle")
+    class ToggleAlarm {
+
+        @Test
+        @DisplayName("성공: 알람 토글")
+        void success() throws Exception {
+            // given
+            Alarm alarm = alarmRepository.save(Alarm.builder()
+                    .user(testUser)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .repeatDays("0111110")
+                    .missionType(MissionType.MATH)
+                    .missionLevel(1)
+                    .isActive(true)
+                    .build());
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/alarms/" + alarm.getId() + "/toggle")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.isActive").value(false));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/alarms/{id}")
+    class DeleteAlarm {
+
+        @Test
+        @DisplayName("성공: 알람 삭제")
+        void success() throws Exception {
+            // given
+            Alarm alarm = alarmRepository.save(Alarm.builder()
+                    .user(testUser)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .repeatDays("0111110")
+                    .missionType(MissionType.MATH)
+                    .missionLevel(1)
+                    .build());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/alarms/" + alarm.getId())
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("DELETED"));
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/controller/TodoControllerTest.java
+++ b/src/test/java/com/pace/server/domain/wake/controller/TodoControllerTest.java
@@ -1,0 +1,170 @@
+package com.pace.server.domain.wake.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.wake.dto.request.CreateTodoRequest;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+import com.pace.server.support.IntegrationTestSupport;
+
+class TodoControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/todos")
+    class GetTodayTodos {
+
+        @Test
+        @DisplayName("성공: 오늘 투두 목록 조회")
+        void success() throws Exception {
+            // given
+            todoRepository.save(Todo.builder()
+                    .user(testUser)
+                    .content("운동하기")
+                    .targetDate(LocalDate.now())
+                    .isDone(false)
+                    .build());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/todos")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data").isArray())
+                    .andExpect(jsonPath("$.data[0].content").value("운동하기"));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/todos")
+    class CreateTodo {
+
+        @Test
+        @DisplayName("성공: 투두 생성")
+        void success() throws Exception {
+            // given
+            CreateTodoRequest request = new CreateTodoRequest("책 읽기");
+
+            // when & then
+            mockMvc.perform(post("/api/v1/todos")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.content").value("책 읽기"))
+                    .andExpect(jsonPath("$.data.isDone").value(false));
+        }
+
+        @Test
+        @DisplayName("실패: 빈 내용")
+        void fail_emptyContent() throws Exception {
+            // given
+            CreateTodoRequest request = new CreateTodoRequest("");
+
+            // when & then
+            mockMvc.perform(post("/api/v1/todos")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest());
+        }
+    }
+
+    @Nested
+    @DisplayName("PATCH /api/v1/todos/{id}/toggle")
+    class ToggleTodo {
+
+        @Test
+        @DisplayName("성공: 투두 완료 토글")
+        void success() throws Exception {
+            // given
+            Todo todo = todoRepository.save(Todo.builder()
+                    .user(testUser)
+                    .content("운동하기")
+                    .targetDate(LocalDate.now())
+                    .isDone(false)
+                    .build());
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/todos/" + todo.getId() + "/toggle")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.isDone").value(true));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/todos/{id}/postpone")
+    class PostponeTodo {
+
+        @Test
+        @DisplayName("성공: 투두 다음날로 미루기")
+        void success() throws Exception {
+            // given
+            Todo todo = todoRepository.save(Todo.builder()
+                    .user(testUser)
+                    .content("운동하기")
+                    .targetDate(LocalDate.now())
+                    .isDone(false)
+                    .build());
+
+            // when & then
+            mockMvc.perform(post("/api/v1/todos/" + todo.getId() + "/postpone")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.targetDate").value(LocalDate.now().plusDays(1).toString()));
+        }
+    }
+
+    @Nested
+    @DisplayName("DELETE /api/v1/todos/{id}")
+    class DeleteTodo {
+
+        @Test
+        @DisplayName("성공: 투두 삭제")
+        void success() throws Exception {
+            // given
+            Todo todo = todoRepository.save(Todo.builder()
+                    .user(testUser)
+                    .content("운동하기")
+                    .targetDate(LocalDate.now())
+                    .isDone(false)
+                    .build());
+
+            // when & then
+            mockMvc.perform(delete("/api/v1/todos/" + todo.getId())
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("DELETED"));
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/controller/WakeControllerTest.java
+++ b/src/test/java/com/pace/server/domain/wake/controller/WakeControllerTest.java
@@ -1,0 +1,121 @@
+package com.pace.server.domain.wake.controller;
+
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.wake.dto.request.WakeLogRequest;
+import com.pace.server.domain.wake.entity.WakeLog;
+import com.pace.server.domain.wake.repository.WakeLogRepository;
+import com.pace.server.support.IntegrationTestSupport;
+
+class WakeControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private WakeLogRepository wakeLogRepository;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/wake/log")
+    class RecordWakeLog {
+
+        @Test
+        @DisplayName("성공: 기상 로그 기록")
+        void success() throws Exception {
+            // given
+            WakeLogRequest request = new WakeLogRequest(LocalTime.of(7, 0), true, 30);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/wake/log")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("CREATED"))
+                    .andExpect(jsonPath("$.data.isSuccess").value(true))
+                    .andExpect(jsonPath("$.data.durationSeconds").value(30));
+        }
+
+        @Test
+        @DisplayName("실패: 미션 시간 너무 짧음")
+        void fail_missionTooFast() throws Exception {
+            // given
+            WakeLogRequest request = new WakeLogRequest(LocalTime.of(7, 0), true, 0);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/wake/log")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)))
+                    .andDo(print())
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value("E_MISSION_TOO_FAST"));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/wake/streak")
+    class GetStreak {
+
+        @Test
+        @DisplayName("성공: 스트릭 조회")
+        void success() throws Exception {
+            // given
+            LocalDate today = LocalDate.now();
+            wakeLogRepository.save(WakeLog.builder()
+                    .user(testUser)
+                    .wakeDate(today)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .isSuccess(true)
+                    .durationSeconds(30)
+                    .build());
+            wakeLogRepository.save(WakeLog.builder()
+                    .user(testUser)
+                    .wakeDate(today.minusDays(1))
+                    .wakeTime(LocalTime.of(7, 0))
+                    .isSuccess(true)
+                    .durationSeconds(25)
+                    .build());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/wake/streak")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.currentStreak").value(2))
+                    .andExpect(jsonPath("$.data.totalSuccessCount").value(2));
+        }
+
+        @Test
+        @DisplayName("성공: 기록 없는 경우")
+        void success_noLogs() throws Exception {
+            mockMvc.perform(get("/api/v1/wake/streak")
+                    .header("Authorization", bearerToken(accessToken)))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.currentStreak").value(0))
+                    .andExpect(jsonPath("$.data.totalSuccessCount").value(0));
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/service/AlarmServiceTest.java
+++ b/src/test/java/com/pace/server/domain/wake/service/AlarmServiceTest.java
@@ -1,0 +1,250 @@
+package com.pace.server.domain.wake.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.CreateAlarmRequest;
+import com.pace.server.domain.wake.dto.request.UpdateAlarmRequest;
+import com.pace.server.domain.wake.dto.response.AlarmResponse;
+import com.pace.server.domain.wake.entity.Alarm;
+import com.pace.server.domain.wake.entity.MissionType;
+import com.pace.server.domain.wake.repository.AlarmRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class AlarmServiceTest {
+
+    @InjectMocks
+    private AlarmService alarmService;
+
+    @Mock
+    private AlarmRepository alarmRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Alarm testAlarm;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        testAlarm = Alarm.builder()
+                .id(1L)
+                .user(testUser)
+                .wakeTime(LocalTime.of(7, 0))
+                .repeatDays("0111110")
+                .missionType(MissionType.MATH)
+                .missionLevel(2)
+                .isActive(true)
+                .label("출근 알람")
+                .build();
+    }
+
+    @Nested
+    @DisplayName("알람 목록 조회")
+    class GetAlarms {
+
+        @Test
+        @DisplayName("성공: 알람 목록이 정상적으로 조회된다")
+        void success() {
+            // given
+            given(alarmRepository.findByUserIdOrderByWakeTimeAsc(1L))
+                    .willReturn(List.of(testAlarm));
+
+            // when
+            List<AlarmResponse> result = alarmService.getAlarms(1L);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).wakeTime()).isEqualTo(LocalTime.of(7, 0));
+        }
+
+        @Test
+        @DisplayName("성공: 알람이 없으면 빈 목록 반환")
+        void success_emptyList() {
+            // given
+            given(alarmRepository.findByUserIdOrderByWakeTimeAsc(1L))
+                    .willReturn(List.of());
+
+            // when
+            List<AlarmResponse> result = alarmService.getAlarms(1L);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("알람 생성")
+    class CreateAlarm {
+
+        @Test
+        @DisplayName("성공: 알람이 정상적으로 생성된다")
+        void success() {
+            // given
+            CreateAlarmRequest request = new CreateAlarmRequest(
+                    LocalTime.of(6, 30),
+                    "1111111",
+                    MissionType.SHAKE,
+                    3,
+                    "새 알람");
+
+            given(alarmRepository.countByUserId(1L)).willReturn(0L);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(alarmRepository.save(any(Alarm.class))).willAnswer(invocation -> {
+                Alarm alarm = invocation.getArgument(0);
+                return Alarm.builder()
+                        .id(2L)
+                        .user(alarm.getUser())
+                        .wakeTime(alarm.getWakeTime())
+                        .repeatDays(alarm.getRepeatDays())
+                        .missionType(alarm.getMissionType())
+                        .missionLevel(alarm.getMissionLevel())
+                        .label(alarm.getLabel())
+                        .isActive(true)
+                        .build();
+            });
+
+            // when
+            AlarmResponse result = alarmService.createAlarm(1L, request);
+
+            // then
+            assertThat(result.wakeTime()).isEqualTo(LocalTime.of(6, 30));
+            assertThat(result.missionType()).isEqualTo(MissionType.SHAKE);
+            then(alarmRepository).should().save(any(Alarm.class));
+        }
+
+        @Test
+        @DisplayName("실패: 알람 개수 10개 초과")
+        void fail_limitExceeded() {
+            // given
+            CreateAlarmRequest request = new CreateAlarmRequest(
+                    LocalTime.of(6, 30), "1111111", MissionType.MATH, 1, null);
+            given(alarmRepository.countByUserId(1L)).willReturn(10L);
+
+            // when & then
+            assertThatThrownBy(() -> alarmService.createAlarm(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALARM_LIMIT_EXCEEDED);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void fail_userNotFound() {
+            // given
+            CreateAlarmRequest request = new CreateAlarmRequest(
+                    LocalTime.of(6, 30), "1111111", MissionType.MATH, 1, null);
+            given(alarmRepository.countByUserId(999L)).willReturn(0L);
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> alarmService.createAlarm(999L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("알람 수정")
+    class UpdateAlarm {
+
+        @Test
+        @DisplayName("성공: 알람이 정상적으로 수정된다")
+        void success() {
+            // given
+            UpdateAlarmRequest request = new UpdateAlarmRequest(
+                    LocalTime.of(8, 0), "0111110", MissionType.SQUAT, 4, "수정된 라벨");
+            given(alarmRepository.findById(1L)).willReturn(Optional.of(testAlarm));
+
+            // when
+            AlarmResponse result = alarmService.updateAlarm(1L, 1L, request);
+
+            // then
+            assertThat(result.wakeTime()).isEqualTo(LocalTime.of(8, 0));
+            assertThat(result.missionType()).isEqualTo(MissionType.SQUAT);
+        }
+
+        @Test
+        @DisplayName("실패: 다른 사용자의 알람")
+        void fail_notOwner() {
+            // given
+            User anotherUser = User.builder().id(2L).build();
+            Alarm anotherAlarm = Alarm.builder().id(2L).user(anotherUser).build();
+
+            UpdateAlarmRequest request = new UpdateAlarmRequest(
+                    LocalTime.of(8, 0), "0111110", MissionType.MATH, 1, null);
+            given(alarmRepository.findById(2L)).willReturn(Optional.of(anotherAlarm));
+
+            // when & then
+            assertThatThrownBy(() -> alarmService.updateAlarm(1L, 2L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ALARM_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("알람 토글")
+    class ToggleAlarm {
+
+        @Test
+        @DisplayName("성공: 알람이 비활성화된다")
+        void success_deactivate() {
+            // given
+            given(alarmRepository.findById(1L)).willReturn(Optional.of(testAlarm));
+
+            // when
+            AlarmResponse result = alarmService.toggleAlarm(1L, 1L);
+
+            // then
+            assertThat(result.isActive()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("알람 삭제")
+    class DeleteAlarm {
+
+        @Test
+        @DisplayName("성공: 알람이 정상적으로 삭제된다")
+        void success() {
+            // given
+            given(alarmRepository.findById(1L)).willReturn(Optional.of(testAlarm));
+
+            // when
+            alarmService.deleteAlarm(1L, 1L);
+
+            // then
+            then(alarmRepository).should().delete(testAlarm);
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/service/TodoServiceTest.java
+++ b/src/test/java/com/pace/server/domain/wake/service/TodoServiceTest.java
@@ -1,0 +1,228 @@
+package com.pace.server.domain.wake.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.CreateTodoRequest;
+import com.pace.server.domain.wake.dto.response.TodoResponse;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+    @InjectMocks
+    private TodoService todoService;
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+    private Todo testTodo;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        testTodo = Todo.builder()
+                .id(1L)
+                .user(testUser)
+                .content("운동하기")
+                .targetDate(LocalDate.now())
+                .isDone(false)
+                .displayOrder(0)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("오늘 투두 목록 조회")
+    class GetTodayTodos {
+
+        @Test
+        @DisplayName("성공: 오늘 투두 목록이 조회된다")
+        void success() {
+            // given
+            given(todoRepository.findByUserIdAndTargetDateOrderByDisplayOrderAsc(eq(1L), any(LocalDate.class)))
+                    .willReturn(List.of(testTodo));
+
+            // when
+            List<TodoResponse> result = todoService.getTodayTodos(1L);
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).content()).isEqualTo("운동하기");
+        }
+
+        @Test
+        @DisplayName("성공: 투두가 없으면 빈 목록 반환")
+        void success_empty() {
+            // given
+            given(todoRepository.findByUserIdAndTargetDateOrderByDisplayOrderAsc(eq(1L), any(LocalDate.class)))
+                    .willReturn(List.of());
+
+            // when
+            List<TodoResponse> result = todoService.getTodayTodos(1L);
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("투두 생성")
+    class CreateTodo {
+
+        @Test
+        @DisplayName("성공: 투두가 정상적으로 생성된다")
+        void success() {
+            // given
+            CreateTodoRequest request = new CreateTodoRequest("새 투두");
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(todoRepository.countByUserIdAndTargetDate(eq(1L), any(LocalDate.class))).willReturn(0L);
+            given(todoRepository.save(any(Todo.class))).willAnswer(invocation -> {
+                Todo todo = invocation.getArgument(0);
+                return Todo.builder()
+                        .id(2L)
+                        .user(todo.getUser())
+                        .content(todo.getContent())
+                        .targetDate(todo.getTargetDate())
+                        .isDone(false)
+                        .displayOrder(0)
+                        .build();
+            });
+
+            // when
+            TodoResponse result = todoService.createTodo(1L, request);
+
+            // then
+            assertThat(result.content()).isEqualTo("새 투두");
+            assertThat(result.isDone()).isFalse();
+            then(todoRepository).should().save(any(Todo.class));
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void fail_userNotFound() {
+            // given
+            CreateTodoRequest request = new CreateTodoRequest("새 투두");
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> todoService.createTodo(999L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("투두 완료 토글")
+    class ToggleTodo {
+
+        @Test
+        @DisplayName("성공: 투두가 완료 상태로 변경된다")
+        void success_markDone() {
+            // given
+            given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo));
+
+            // when
+            TodoResponse result = todoService.toggleTodo(1L, 1L);
+
+            // then
+            assertThat(result.isDone()).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패: 다른 사용자의 투두")
+        void fail_notOwner() {
+            // given
+            User anotherUser = User.builder().id(2L).build();
+            Todo anotherTodo = Todo.builder().id(2L).user(anotherUser).build();
+            given(todoRepository.findById(2L)).willReturn(Optional.of(anotherTodo));
+
+            // when & then
+            assertThatThrownBy(() -> todoService.toggleTodo(1L, 2L))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.RESOURCE_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("투두 미루기")
+    class PostponeTodo {
+
+        @Test
+        @DisplayName("성공: 투두가 다음날로 미뤄진다")
+        void success() {
+            // given
+            given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo));
+            given(todoRepository.save(any(Todo.class))).willAnswer(invocation -> {
+                Todo todo = invocation.getArgument(0);
+                return Todo.builder()
+                        .id(2L)
+                        .user(todo.getUser())
+                        .content(todo.getContent())
+                        .targetDate(todo.getTargetDate())
+                        .isDone(false)
+                        .build();
+            });
+
+            // when
+            TodoResponse result = todoService.postponeTodo(1L, 1L);
+
+            // then
+            assertThat(result.targetDate()).isEqualTo(LocalDate.now().plusDays(1));
+            then(todoRepository).should().delete(testTodo);
+            then(todoRepository).should().save(any(Todo.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("투두 삭제")
+    class DeleteTodo {
+
+        @Test
+        @DisplayName("성공: 투두가 정상적으로 삭제된다")
+        void success() {
+            // given
+            given(todoRepository.findById(1L)).willReturn(Optional.of(testTodo));
+
+            // when
+            todoService.deleteTodo(1L, 1L);
+
+            // then
+            then(todoRepository).should().delete(testTodo);
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/wake/service/WakeLogServiceTest.java
+++ b/src/test/java/com/pace/server/domain/wake/service/WakeLogServiceTest.java
@@ -1,0 +1,217 @@
+package com.pace.server.domain.wake.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.member.repository.UserRepository;
+import com.pace.server.domain.wake.dto.request.WakeLogRequest;
+import com.pace.server.domain.wake.dto.response.StreakResponse;
+import com.pace.server.domain.wake.dto.response.WakeLogResponse;
+import com.pace.server.domain.wake.entity.WakeLog;
+import com.pace.server.domain.wake.repository.WakeLogRepository;
+import com.pace.server.global.common.code.ErrorCode;
+import com.pace.server.global.error.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+class WakeLogServiceTest {
+
+    @InjectMocks
+    private WakeLogService wakeLogService;
+
+    @Mock
+    private WakeLogRepository wakeLogRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("기상 로그 기록")
+    class RecordWakeLog {
+
+        @Test
+        @DisplayName("성공: 기상 로그가 정상적으로 기록된다")
+        void success() {
+            // given
+            WakeLogRequest request = new WakeLogRequest(LocalTime.of(7, 0), true, 30);
+            given(userRepository.findById(1L)).willReturn(Optional.of(testUser));
+            given(wakeLogRepository.save(any(WakeLog.class))).willAnswer(invocation -> {
+                WakeLog log = invocation.getArgument(0);
+                return WakeLog.builder()
+                        .id(1L)
+                        .user(log.getUser())
+                        .wakeDate(LocalDate.now())
+                        .wakeTime(log.getWakeTime())
+                        .isSuccess(log.isSuccess())
+                        .durationSeconds(log.getDurationSeconds())
+                        .build();
+            });
+
+            // when
+            WakeLogResponse result = wakeLogService.recordWakeLog(1L, request);
+
+            // then
+            assertThat(result.isSuccess()).isTrue();
+            assertThat(result.durationSeconds()).isEqualTo(30);
+            then(wakeLogRepository).should().save(any(WakeLog.class));
+        }
+
+        @Test
+        @DisplayName("실패: 미션 수행 시간이 너무 짧음 (어뷰징)")
+        void fail_missionTooFast() {
+            // given
+            WakeLogRequest request = new WakeLogRequest(LocalTime.of(7, 0), true, 0);
+
+            // when & then
+            assertThatThrownBy(() -> wakeLogService.recordWakeLog(1L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.MISSION_TOO_FAST);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자")
+        void fail_userNotFound() {
+            // given
+            WakeLogRequest request = new WakeLogRequest(LocalTime.of(7, 0), true, 30);
+            given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> wakeLogService.recordWakeLog(999L, request))
+                    .isInstanceOf(BusinessException.class)
+                    .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+        }
+    }
+
+    @Nested
+    @DisplayName("연속 기상 스트릭 조회")
+    class GetStreak {
+
+        @Test
+        @DisplayName("성공: 연속 3일 스트릭")
+        void success_threeDay() {
+            // given
+            LocalDate today = LocalDate.now();
+            List<WakeLog> logs = List.of(
+                    createWakeLog(today),
+                    createWakeLog(today.minusDays(1)),
+                    createWakeLog(today.minusDays(2)));
+
+            given(wakeLogRepository.findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(1L))
+                    .willReturn(logs);
+            given(wakeLogRepository.countByUserIdAndIsSuccessTrue(1L))
+                    .willReturn(10L);
+
+            // when
+            StreakResponse result = wakeLogService.getStreak(1L);
+
+            // then
+            assertThat(result.currentStreak()).isEqualTo(3);
+            assertThat(result.totalSuccessCount()).isEqualTo(10);
+        }
+
+        @Test
+        @DisplayName("성공: 어제부터 시작하는 스트릭")
+        void success_fromYesterday() {
+            // given
+            LocalDate today = LocalDate.now();
+            List<WakeLog> logs = List.of(
+                    createWakeLog(today.minusDays(1)),
+                    createWakeLog(today.minusDays(2)));
+
+            given(wakeLogRepository.findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(1L))
+                    .willReturn(logs);
+            given(wakeLogRepository.countByUserIdAndIsSuccessTrue(1L))
+                    .willReturn(2L);
+
+            // when
+            StreakResponse result = wakeLogService.getStreak(1L);
+
+            // then
+            assertThat(result.currentStreak()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("성공: 스트릭 끊김 (2일 전 기록 없음)")
+        void success_brokenStreak() {
+            // given
+            LocalDate today = LocalDate.now();
+            List<WakeLog> logs = List.of(
+                    createWakeLog(today),
+                    createWakeLog(today.minusDays(3)) // 2일 건너뜀
+            );
+
+            given(wakeLogRepository.findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(1L))
+                    .willReturn(logs);
+            given(wakeLogRepository.countByUserIdAndIsSuccessTrue(1L))
+                    .willReturn(2L);
+
+            // when
+            StreakResponse result = wakeLogService.getStreak(1L);
+
+            // then
+            assertThat(result.currentStreak()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("성공: 기록이 없는 경우")
+        void success_noLogs() {
+            // given
+            given(wakeLogRepository.findByUserIdAndIsSuccessTrueOrderByWakeDateDesc(1L))
+                    .willReturn(List.of());
+            given(wakeLogRepository.countByUserIdAndIsSuccessTrue(1L))
+                    .willReturn(0L);
+
+            // when
+            StreakResponse result = wakeLogService.getStreak(1L);
+
+            // then
+            assertThat(result.currentStreak()).isZero();
+            assertThat(result.maxStreak()).isZero();
+            assertThat(result.totalSuccessCount()).isZero();
+        }
+
+        private WakeLog createWakeLog(LocalDate date) {
+            return WakeLog.builder()
+                    .id(1L)
+                    .user(testUser)
+                    .wakeDate(date)
+                    .wakeTime(LocalTime.of(7, 0))
+                    .isSuccess(true)
+                    .durationSeconds(30)
+                    .build();
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련 이슈 번호를 링크해주세요 (예: closes #123) -->
closes #7 

## 📝 변경 사항
<!-- 주요 변경 내용을 요약해주세요 -->
- Alarm API 구현 (CRUD + 토글, 최대 10개 제한)
- WakeLog API 구현 (기상 로그 기록, 스트릭 계산)
- Todo API 구현 (CRUD + 완료 토글 + 미루기)
- 단위 테스트 3개, 통합 테스트 3개 추가

## 🔍 변경 유형
- [x] 새로운 기능 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 추가/수정 (test)
- [ ] 설정 변경 (chore)

## ✅ 체크리스트
- [x] 로컬에서 빌드 성공 (`./gradlew build`)
- [x] 테스트 통과 (`./gradlew test`)
- [ ] 코드 스타일 준수
- [x] 관련 문서 업데이트 (필요시)

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 💬 리뷰어에게
<!-- 리뷰 시 중점적으로 봐줬으면 하는 부분이 있다면 작성해주세요 -->
