### PR TITLE
feat: Recap 도메인 API 구현

### DIFF
--- a/src/main/java/com/pace/server/domain/recap/cache/RecapCacheRepository.java
+++ b/src/main/java/com/pace/server/domain/recap/cache/RecapCacheRepository.java
@@ -1,0 +1,81 @@
+package com.pace.server.domain.recap.cache;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pace.server.domain.recap.dto.RecapResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Redis 기반 리캡 데이터 캐시 Repository
+ * Key 형식: recap:{userId}:{date}
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RecapCacheRepository {
+
+    private static final String KEY_PREFIX = "recap:";
+    private static final Duration TTL = Duration.ofHours(6);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 캐시에서 리캡 데이터 조회
+     */
+    public Optional<RecapResponse> findByUserIdAndDate(Long userId, LocalDate date) {
+        String key = buildKey(userId, date);
+        String json = redisTemplate.opsForValue().get(key);
+
+        if (json == null) {
+            log.debug("Cache miss for key: {}", key);
+            return Optional.empty();
+        }
+
+        try {
+            RecapResponse data = objectMapper.readValue(json, RecapResponse.class);
+            log.debug("Cache hit for key: {}", key);
+            return Optional.of(data);
+        } catch (Exception e) {
+            log.error("Failed to deserialize recap data for key: {}", key, e);
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * 캐시에 리캡 데이터 저장
+     */
+    public void save(Long userId, LocalDate date, RecapResponse data) {
+        String key = buildKey(userId, date);
+
+        try {
+            String json = objectMapper.writeValueAsString(data);
+            redisTemplate.opsForValue().set(key, json, TTL);
+            log.debug("Cached recap data for key: {}", key);
+        } catch (Exception e) {
+            log.error("Failed to cache recap data for key: {}", key, e);
+        }
+    }
+
+    /**
+     * 캐시 삭제
+     */
+    public void evict(Long userId, LocalDate date) {
+        String key = buildKey(userId, date);
+        redisTemplate.delete(key);
+        log.debug("Evicted cache for key: {}", key);
+    }
+
+    private String buildKey(Long userId, LocalDate date) {
+        return KEY_PREFIX + userId + ":" + date.format(DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/controller/RecapController.java
+++ b/src/main/java/com/pace/server/domain/recap/controller/RecapController.java
@@ -1,0 +1,32 @@
+package com.pace.server.domain.recap.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.pace.server.domain.recap.dto.RecapResponse;
+import com.pace.server.domain.recap.service.RecapService;
+import com.pace.server.global.common.response.ApiResponse;
+import com.pace.server.global.security.jwt.JwtAuthentication;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Recap", description = "모닝 리캡 API")
+@RestController
+@RequestMapping("/api/v1/recap")
+@RequiredArgsConstructor
+public class RecapController {
+
+    private final RecapService recapService;
+
+    @Operation(summary = "오늘의 모닝 리캡 조회", description = "오늘의 날씨, 뉴스, 금융, 투두 정보를 조합하여 리캡 데이터를 반환합니다.")
+    @GetMapping
+    public ApiResponse<RecapResponse> getRecap(
+            @AuthenticationPrincipal JwtAuthentication principal) {
+        RecapResponse response = recapService.getRecap(principal.userId());
+        return ApiResponse.ok(response);
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/dto/NewsSummary.java
+++ b/src/main/java/com/pace/server/domain/recap/dto/NewsSummary.java
@@ -1,0 +1,20 @@
+package com.pace.server.domain.recap.dto;
+
+import lombok.Builder;
+
+/**
+ * 뉴스 정보 요약 DTO
+ */
+@Builder
+public record NewsSummary(
+        String title,
+        String summary,
+        String link,
+        String category) {
+    public static NewsSummary of(String title, String summary) {
+        return NewsSummary.builder()
+                .title(title)
+                .summary(summary)
+                .build();
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/dto/RecapResponse.java
+++ b/src/main/java/com/pace/server/domain/recap/dto/RecapResponse.java
@@ -1,0 +1,29 @@
+package com.pace.server.domain.recap.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.Builder;
+
+/**
+ * 모닝 리캡 API 응답 DTO
+ */
+@Builder
+public record RecapResponse(
+        LocalDate date,
+        WeatherSummary weather,
+        List<NewsSummary> news,
+        List<StockSummary> finance,
+        List<String> todos,
+        String motivationMessage) {
+    public static RecapResponse empty(LocalDate date) {
+        return RecapResponse.builder()
+                .date(date)
+                .weather(WeatherSummary.empty())
+                .news(List.of())
+                .finance(List.of())
+                .todos(List.of())
+                .motivationMessage("🌟 오늘도 화이팅!")
+                .build();
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/dto/StockSummary.java
+++ b/src/main/java/com/pace/server/domain/recap/dto/StockSummary.java
@@ -1,0 +1,27 @@
+package com.pace.server.domain.recap.dto;
+
+import lombok.Builder;
+
+/**
+ * 주식/금융 정보 요약 DTO
+ */
+@Builder
+public record StockSummary(
+        String code,
+        String name,
+        double currentPrice,
+        double changeAmount,
+        double changePercent,
+        String changeSign // 상승/하락/보합
+) {
+    public static StockSummary empty(String code) {
+        return StockSummary.builder()
+                .code(code)
+                .name("정보 없음")
+                .currentPrice(0)
+                .changeAmount(0)
+                .changePercent(0)
+                .changeSign("보합")
+                .build();
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/dto/WeatherSummary.java
+++ b/src/main/java/com/pace/server/domain/recap/dto/WeatherSummary.java
@@ -1,0 +1,23 @@
+package com.pace.server.domain.recap.dto;
+
+import lombok.Builder;
+
+/**
+ * 날씨 정보 요약 DTO
+ */
+@Builder
+public record WeatherSummary(
+        String regionName,
+        Double temperature,
+        String condition,
+        Integer precipitationProbability,
+        boolean umbrellaNeeded,
+        boolean isFallback,
+        String fallbackMessage) {
+    public static WeatherSummary empty() {
+        return WeatherSummary.builder()
+                .isFallback(true)
+                .fallbackMessage("날씨 정보를 불러올 수 없습니다.")
+                .build();
+    }
+}

--- a/src/main/java/com/pace/server/domain/recap/service/RecapService.java
+++ b/src/main/java/com/pace/server/domain/recap/service/RecapService.java
@@ -1,0 +1,121 @@
+package com.pace.server.domain.recap.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.pace.server.domain.recap.cache.RecapCacheRepository;
+import com.pace.server.domain.recap.dto.NewsSummary;
+import com.pace.server.domain.recap.dto.RecapResponse;
+import com.pace.server.domain.recap.dto.StockSummary;
+import com.pace.server.domain.recap.dto.WeatherSummary;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * 모닝 리캡 서비스
+ * Redis 캐시 조회 → Cache Miss 시 On-demand Fetch
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RecapService {
+
+    private final RecapCacheRepository cacheRepository;
+    private final TodoRepository todoRepository;
+
+    // TODO: 외부 API 서비스 연동 후 주입
+    // private final WeatherService weatherService;
+    // private final NewsService newsService;
+    // private final FinanceService financeService;
+
+    /**
+     * 오늘의 모닝 리캡 조회
+     */
+    public RecapResponse getRecap(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        // 1. 캐시 조회 (배치에서 미리 생성된 데이터)
+        return cacheRepository.findByUserIdAndDate(userId, today)
+                .orElseGet(() -> {
+                    // 2. Cache Miss → On-demand Fetch
+                    log.info("Cache miss for user {}, fetching on-demand", userId);
+                    RecapResponse response = fetchOnDemand(userId, today);
+
+                    // 3. 캐시에 저장
+                    cacheRepository.save(userId, today, response);
+                    return response;
+                });
+    }
+
+    /**
+     * On-demand로 리캡 데이터 조합
+     * TODO: 외부 API 연동 후 Structured Concurrency로 병렬 호출
+     */
+    private RecapResponse fetchOnDemand(Long userId, LocalDate today) {
+        // 현재는 Todo만 조회, 나머지는 더미 데이터
+        List<Todo> todos = todoRepository.findByUserIdAndTargetDateAndIsDoneFalse(userId, today);
+        List<String> todoContents = todos.stream()
+                .map(Todo::getContent)
+                .toList();
+
+        return RecapResponse.builder()
+                .date(today)
+                .weather(createPlaceholderWeather())
+                .news(createPlaceholderNews())
+                .finance(createPlaceholderFinance())
+                .todos(todoContents)
+                .motivationMessage(getMotivationMessage())
+                .build();
+    }
+
+    private WeatherSummary createPlaceholderWeather() {
+        return WeatherSummary.builder()
+                .regionName("서울")
+                .temperature(15.0)
+                .condition("맑음")
+                .precipitationProbability(10)
+                .umbrellaNeeded(false)
+                .isFallback(true)
+                .fallbackMessage("외부 API 연동 후 실제 데이터가 표시됩니다.")
+                .build();
+    }
+
+    private List<NewsSummary> createPlaceholderNews() {
+        return List.of(
+                NewsSummary.builder()
+                        .title("뉴스 API 연동 예정")
+                        .summary("네이버 뉴스 API 연동 후 실제 뉴스가 표시됩니다.")
+                        .category("안내")
+                        .build());
+    }
+
+    private List<StockSummary> createPlaceholderFinance() {
+        return List.of(
+                StockSummary.builder()
+                        .code("005930")
+                        .name("삼성전자")
+                        .currentPrice(0)
+                        .changeAmount(0)
+                        .changePercent(0)
+                        .changeSign("보합")
+                        .build());
+    }
+
+    private String getMotivationMessage() {
+        String[] messages = {
+                "🌟 오늘도 한 걸음 더",
+                "💪 시작이 반이다",
+                "🔥 당신은 할 수 있다",
+                "✨ 매일이 새로운 기회",
+                "🚀 꾸준함이 재능을 이긴다"
+        };
+        return messages[(int) (Math.random() * messages.length)];
+    }
+}

--- a/src/test/java/com/pace/server/domain/recap/controller/RecapControllerTest.java
+++ b/src/test/java/com/pace/server/domain/recap/controller/RecapControllerTest.java
@@ -1,0 +1,89 @@
+package com.pace.server.domain.recap.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+import com.pace.server.support.IntegrationTestSupport;
+
+@DisplayName("RecapController 통합 테스트")
+class RecapControllerTest extends IntegrationTestSupport {
+
+    @Autowired
+    private TodoRepository todoRepository;
+
+    private User testUser;
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        testUser = createTestUser();
+        accessToken = createAccessToken(testUser);
+    }
+
+    @Nested
+    @DisplayName("GET /api/v1/recap")
+    class GetRecap {
+
+        @Test
+        @DisplayName("성공: 오늘의 모닝 리캡 조회")
+        void success() throws Exception {
+            // given
+            Todo todo = todoRepository.save(Todo.builder()
+                    .user(testUser)
+                    .content("통합 테스트 할일")
+                    .targetDate(LocalDate.now())
+                    .isDone(false)
+                    .build());
+
+            // when & then
+            mockMvc.perform(get("/api/v1/recap")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.date").value(LocalDate.now().toString()))
+                    .andExpect(jsonPath("$.data.todos").isArray())
+                    .andExpect(jsonPath("$.data.todos[0]").value("통합 테스트 할일"))
+                    .andExpect(jsonPath("$.data.weather").exists())
+                    .andExpect(jsonPath("$.data.motivationMessage").isNotEmpty());
+        }
+
+        @Test
+        @DisplayName("성공: 투두 없이 조회")
+        void success_noTodos() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/recap")
+                    .header("Authorization", bearerToken(accessToken))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.code").value("SUCCESS"))
+                    .andExpect(jsonPath("$.data.todos").isArray())
+                    .andExpect(jsonPath("$.data.todos").isEmpty());
+        }
+
+        @Test
+        @DisplayName("실패: 인증 없이 요청")
+        void fail_unauthorized() throws Exception {
+            // when & then
+            mockMvc.perform(get("/api/v1/recap")
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andDo(print())
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+}

--- a/src/test/java/com/pace/server/domain/recap/service/RecapServiceTest.java
+++ b/src/test/java/com/pace/server/domain/recap/service/RecapServiceTest.java
@@ -1,0 +1,132 @@
+package com.pace.server.domain.recap.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.pace.server.domain.member.entity.Provider;
+import com.pace.server.domain.member.entity.Role;
+import com.pace.server.domain.member.entity.User;
+import com.pace.server.domain.member.entity.UserStatus;
+import com.pace.server.domain.recap.cache.RecapCacheRepository;
+import com.pace.server.domain.recap.dto.RecapResponse;
+import com.pace.server.domain.wake.entity.Todo;
+import com.pace.server.domain.wake.repository.TodoRepository;
+
+@ExtendWith(MockitoExtension.class)
+class RecapServiceTest {
+
+    @InjectMocks
+    private RecapService recapService;
+
+    @Mock
+    private RecapCacheRepository cacheRepository;
+
+    @Mock
+    private TodoRepository todoRepository;
+
+    private User testUser;
+    private Todo testTodo;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        today = LocalDate.now();
+
+        testUser = User.builder()
+                .id(1L)
+                .email("test@test.com")
+                .nickname("테스터")
+                .provider(Provider.KAKAO)
+                .providerId("12345")
+                .role(Role.ROLE_USER)
+                .status(UserStatus.ACTIVE)
+                .build();
+
+        testTodo = Todo.builder()
+                .id(1L)
+                .user(testUser)
+                .content("테스트 할일")
+                .targetDate(today)
+                .isDone(false)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("모닝 리캡 조회")
+    class GetRecap {
+
+        @Test
+        @DisplayName("성공: 캐시에서 조회된다 (Cache Hit)")
+        void success_cacheHit() {
+            // given
+            RecapResponse cachedResponse = RecapResponse.builder()
+                    .date(today)
+                    .todos(List.of("캐시된 할일"))
+                    .motivationMessage("💪 화이팅!")
+                    .build();
+
+            given(cacheRepository.findByUserIdAndDate(1L, today))
+                    .willReturn(Optional.of(cachedResponse));
+
+            // when
+            RecapResponse result = recapService.getRecap(1L);
+
+            // then
+            assertThat(result.date()).isEqualTo(today);
+            assertThat(result.todos()).containsExactly("캐시된 할일");
+            then(todoRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("성공: 캐시 미스 시 On-demand Fetch")
+        void success_cacheMiss() {
+            // given
+            given(cacheRepository.findByUserIdAndDate(1L, today))
+                    .willReturn(Optional.empty());
+            given(todoRepository.findByUserIdAndTargetDateAndIsDoneFalse(1L, today))
+                    .willReturn(List.of(testTodo));
+
+            // when
+            RecapResponse result = recapService.getRecap(1L);
+
+            // then
+            assertThat(result.date()).isEqualTo(today);
+            assertThat(result.todos()).containsExactly("테스트 할일");
+            assertThat(result.weather()).isNotNull();
+            assertThat(result.motivationMessage()).isNotNull();
+
+            // 캐시에 저장 확인
+            then(cacheRepository).should().save(eq(1L), eq(today), any(RecapResponse.class));
+        }
+
+        @Test
+        @DisplayName("성공: 투두가 없으면 빈 목록 반환")
+        void success_emptyTodos() {
+            // given
+            given(cacheRepository.findByUserIdAndDate(1L, today))
+                    .willReturn(Optional.empty());
+            given(todoRepository.findByUserIdAndTargetDateAndIsDoneFalse(1L, today))
+                    .willReturn(List.of());
+
+            // when
+            RecapResponse result = recapService.getRecap(1L);
+
+            // then
+            assertThat(result.todos()).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
closes #9 

## 📝 변경 사항
- Recap 도메인 DTO 추가 (WeatherSummary, NewsSummary, StockSummary, RecapResponse)
- Redis 기반 RecapCacheRepository 구현 (TTL 6시간)
- RecapService: 캐시 우선 조회, Cache Miss 시 On-demand Fetch
- RecapController: GET /api/v1/recap API 추가
- 단위/통합 테스트 추가

## 🔍 변경 유형
- [x] 새로운 기능 (feat)
- [x] 테스트 추가/수정 (test)

## ✅ 체크리스트
- [x] 로컬에서 빌드 성공 (`./gradlew build`)
- [x] 테스트 통과 (`./gradlew test`)
- [x] 코드 스타일 준수
- [x] 관련 문서 업데이트 (CLAUDE.md)

## 💬 리뷰어에게
- 외부 API 연동 전 placeholder 데이터 사용 중
- RecapAssembler (Structured Concurrency)는 외부 API 연동 시 추가 예정
